### PR TITLE
Make Pin function Public

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,37 +2,37 @@ PODS:
   - KIF (3.7.4):
     - KIF/Core (= 3.7.4)
   - KIF/Core (3.7.4)
-  - VOKUtilities (0.14.0):
-    - "VOKUtilities/NSCalendar+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSNumberFormatter+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSPredicate+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSString+VOKValidation (= 0.14.0)"
-    - "VOKUtilities/UIColor+VOKAL (= 0.14.0)"
-    - "VOKUtilities/UIView+VOKCircle (= 0.14.0)"
-    - "VOKUtilities/UIView+VOKDebug (= 0.14.0)"
-    - "VOKUtilities/UIViewController+VOKKeyboard (= 0.14.0)"
-    - VOKUtilities/VOKAlertHelper (= 0.14.0)
-    - VOKUtilities/VOKEmailHelper (= 0.14.0)
-    - VOKUtilities/VOKIBHelpers (= 0.14.0)
-    - VOKUtilities/VOKKeyPathHelper (= 0.14.0)
-    - VOKUtilities/VOKNavigationHelper (= 0.14.0)
-    - VOKUtilities/VOKSwiftHelpers (= 0.14.0)
-    - VOKUtilities/VOKSwiftTestingHelpers (= 0.14.0)
-  - "VOKUtilities/NSCalendar+VOKAL (0.14.0)"
-  - "VOKUtilities/NSNumberFormatter+VOKAL (0.14.0)"
-  - "VOKUtilities/NSPredicate+VOKAL (0.14.0)"
-  - "VOKUtilities/NSString+VOKValidation (0.14.0)"
-  - "VOKUtilities/UIColor+VOKAL (0.14.0)"
-  - "VOKUtilities/UIView+VOKCircle (0.14.0)"
-  - "VOKUtilities/UIView+VOKDebug (0.14.0)"
-  - "VOKUtilities/UIViewController+VOKKeyboard (0.14.0)"
-  - VOKUtilities/VOKAlertHelper (0.14.0)
-  - VOKUtilities/VOKEmailHelper (0.14.0)
-  - VOKUtilities/VOKIBHelpers (0.14.0)
-  - VOKUtilities/VOKKeyPathHelper (0.14.0)
-  - VOKUtilities/VOKNavigationHelper (0.14.0)
-  - VOKUtilities/VOKSwiftHelpers (0.14.0)
-  - VOKUtilities/VOKSwiftTestingHelpers (0.14.0)
+  - VOKUtilities (0.15.0):
+    - "VOKUtilities/NSCalendar+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSNumberFormatter+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSPredicate+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSString+VOKValidation (= 0.15.0)"
+    - "VOKUtilities/UIColor+VOKAL (= 0.15.0)"
+    - "VOKUtilities/UIView+VOKCircle (= 0.15.0)"
+    - "VOKUtilities/UIView+VOKDebug (= 0.15.0)"
+    - "VOKUtilities/UIViewController+VOKKeyboard (= 0.15.0)"
+    - VOKUtilities/VOKAlertHelper (= 0.15.0)
+    - VOKUtilities/VOKEmailHelper (= 0.15.0)
+    - VOKUtilities/VOKIBHelpers (= 0.15.0)
+    - VOKUtilities/VOKKeyPathHelper (= 0.15.0)
+    - VOKUtilities/VOKNavigationHelper (= 0.15.0)
+    - VOKUtilities/VOKSwiftHelpers (= 0.15.0)
+    - VOKUtilities/VOKSwiftTestingHelpers (= 0.15.0)
+  - "VOKUtilities/NSCalendar+VOKAL (0.15.0)"
+  - "VOKUtilities/NSNumberFormatter+VOKAL (0.15.0)"
+  - "VOKUtilities/NSPredicate+VOKAL (0.15.0)"
+  - "VOKUtilities/NSString+VOKValidation (0.15.0)"
+  - "VOKUtilities/UIColor+VOKAL (0.15.0)"
+  - "VOKUtilities/UIView+VOKCircle (0.15.0)"
+  - "VOKUtilities/UIView+VOKDebug (0.15.0)"
+  - "VOKUtilities/UIViewController+VOKKeyboard (0.15.0)"
+  - VOKUtilities/VOKAlertHelper (0.15.0)
+  - VOKUtilities/VOKEmailHelper (0.15.0)
+  - VOKUtilities/VOKIBHelpers (0.15.0)
+  - VOKUtilities/VOKKeyPathHelper (0.15.0)
+  - VOKUtilities/VOKNavigationHelper (0.15.0)
+  - VOKUtilities/VOKSwiftHelpers (0.15.0)
+  - VOKUtilities/VOKSwiftTestingHelpers (0.15.0)
 
 DEPENDENCIES:
   - KIF (~> 3.7.4)
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   KIF: f3d01c109ee9d1cfe6b0f2bb2aa278e807e971e2
-  VOKUtilities: 0fb1775399971a0ef31ea7b978257b701149bd1f
+  VOKUtilities: 0eedfe8360fdf475b33c3dede2eb4cc80bc0c4ec
 
 PODFILE CHECKSUM: 23511bacd73dc18331115b71ac9e98783d790099
 

--- a/Example/Pods/Local Podspecs/VOKUtilities.podspec.json
+++ b/Example/Pods/Local Podspecs/VOKUtilities.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "VOKUtilities",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "summary": "Assorted category and utility classes for iDevelopment",
   "homepage": "https://github.com/vokal/VOKUtilities",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/vokal/VOKUtilities.git",
-    "tag": "0.14.0"
+    "tag": "0.15.0"
   },
   "platforms": {
     "ios": "11.0",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -2,37 +2,37 @@ PODS:
   - KIF (3.7.4):
     - KIF/Core (= 3.7.4)
   - KIF/Core (3.7.4)
-  - VOKUtilities (0.14.0):
-    - "VOKUtilities/NSCalendar+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSNumberFormatter+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSPredicate+VOKAL (= 0.14.0)"
-    - "VOKUtilities/NSString+VOKValidation (= 0.14.0)"
-    - "VOKUtilities/UIColor+VOKAL (= 0.14.0)"
-    - "VOKUtilities/UIView+VOKCircle (= 0.14.0)"
-    - "VOKUtilities/UIView+VOKDebug (= 0.14.0)"
-    - "VOKUtilities/UIViewController+VOKKeyboard (= 0.14.0)"
-    - VOKUtilities/VOKAlertHelper (= 0.14.0)
-    - VOKUtilities/VOKEmailHelper (= 0.14.0)
-    - VOKUtilities/VOKIBHelpers (= 0.14.0)
-    - VOKUtilities/VOKKeyPathHelper (= 0.14.0)
-    - VOKUtilities/VOKNavigationHelper (= 0.14.0)
-    - VOKUtilities/VOKSwiftHelpers (= 0.14.0)
-    - VOKUtilities/VOKSwiftTestingHelpers (= 0.14.0)
-  - "VOKUtilities/NSCalendar+VOKAL (0.14.0)"
-  - "VOKUtilities/NSNumberFormatter+VOKAL (0.14.0)"
-  - "VOKUtilities/NSPredicate+VOKAL (0.14.0)"
-  - "VOKUtilities/NSString+VOKValidation (0.14.0)"
-  - "VOKUtilities/UIColor+VOKAL (0.14.0)"
-  - "VOKUtilities/UIView+VOKCircle (0.14.0)"
-  - "VOKUtilities/UIView+VOKDebug (0.14.0)"
-  - "VOKUtilities/UIViewController+VOKKeyboard (0.14.0)"
-  - VOKUtilities/VOKAlertHelper (0.14.0)
-  - VOKUtilities/VOKEmailHelper (0.14.0)
-  - VOKUtilities/VOKIBHelpers (0.14.0)
-  - VOKUtilities/VOKKeyPathHelper (0.14.0)
-  - VOKUtilities/VOKNavigationHelper (0.14.0)
-  - VOKUtilities/VOKSwiftHelpers (0.14.0)
-  - VOKUtilities/VOKSwiftTestingHelpers (0.14.0)
+  - VOKUtilities (0.15.0):
+    - "VOKUtilities/NSCalendar+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSNumberFormatter+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSPredicate+VOKAL (= 0.15.0)"
+    - "VOKUtilities/NSString+VOKValidation (= 0.15.0)"
+    - "VOKUtilities/UIColor+VOKAL (= 0.15.0)"
+    - "VOKUtilities/UIView+VOKCircle (= 0.15.0)"
+    - "VOKUtilities/UIView+VOKDebug (= 0.15.0)"
+    - "VOKUtilities/UIViewController+VOKKeyboard (= 0.15.0)"
+    - VOKUtilities/VOKAlertHelper (= 0.15.0)
+    - VOKUtilities/VOKEmailHelper (= 0.15.0)
+    - VOKUtilities/VOKIBHelpers (= 0.15.0)
+    - VOKUtilities/VOKKeyPathHelper (= 0.15.0)
+    - VOKUtilities/VOKNavigationHelper (= 0.15.0)
+    - VOKUtilities/VOKSwiftHelpers (= 0.15.0)
+    - VOKUtilities/VOKSwiftTestingHelpers (= 0.15.0)
+  - "VOKUtilities/NSCalendar+VOKAL (0.15.0)"
+  - "VOKUtilities/NSNumberFormatter+VOKAL (0.15.0)"
+  - "VOKUtilities/NSPredicate+VOKAL (0.15.0)"
+  - "VOKUtilities/NSString+VOKValidation (0.15.0)"
+  - "VOKUtilities/UIColor+VOKAL (0.15.0)"
+  - "VOKUtilities/UIView+VOKCircle (0.15.0)"
+  - "VOKUtilities/UIView+VOKDebug (0.15.0)"
+  - "VOKUtilities/UIViewController+VOKKeyboard (0.15.0)"
+  - VOKUtilities/VOKAlertHelper (0.15.0)
+  - VOKUtilities/VOKEmailHelper (0.15.0)
+  - VOKUtilities/VOKIBHelpers (0.15.0)
+  - VOKUtilities/VOKKeyPathHelper (0.15.0)
+  - VOKUtilities/VOKNavigationHelper (0.15.0)
+  - VOKUtilities/VOKSwiftHelpers (0.15.0)
+  - VOKUtilities/VOKSwiftTestingHelpers (0.15.0)
 
 DEPENDENCIES:
   - KIF (~> 3.7.4)
@@ -48,7 +48,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   KIF: f3d01c109ee9d1cfe6b0f2bb2aa278e807e971e2
-  VOKUtilities: 0fb1775399971a0ef31ea7b978257b701149bd1f
+  VOKUtilities: 0eedfe8360fdf475b33c3dede2eb4cc80bc0c4ec
 
 PODFILE CHECKSUM: 23511bacd73dc18331115b71ac9e98783d790099
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,519 +7,519 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0172F1A5EDF0BCCA3FC8E54673FD3D0C /* KIFTypist.h in Headers */ = {isa = PBXBuildFile; fileRef = 1169221C7B97C2DAFB2BBCFFA16DF5BC /* KIFTypist.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		01F647DA723DF805171D67C9FF381900 /* CAAnimation+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DA5CD3CB63E36161B8B3F7D2AE992D4 /* CAAnimation+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		05F89AC90E1444F6C9FD8C3F95149365 /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		066BD2E7DC764467FEE88CB5B2FE0EBD /* KIFTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 517ED2C363C638C9C87EA07B44DAD95E /* KIFTestActor.m */; };
-		08CB8C86F6D40F62A21BEDBE3EE86D57 /* UIAutomationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = AA3F3D748D9A4FAA1553646F0F74CA75 /* UIAutomationHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0AF303A4B91FED23278F67F9ACE03E9E /* UITouch-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FB06D11E197EF0BDC986163FDFD5DAE /* UITouch-KIFAdditions.m */; };
-		0B064D60B3A726A01F6C9A4BBD22B063 /* VOKAlertHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 377FB8124253238FE62A2FCD52DF4A28 /* VOKAlertHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0DB6887BC743441845D8077845F54630 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */; };
-		0E38022AB7351C5EA1B6465F29471420 /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		0EC1E7C9C7D4FDF0A3C94184D8DBB593 /* UIScreen+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5F24D5CCABD1FA509BE921C30D445 /* UIScreen+KIFAdditions.m */; };
-		0EEAD81094CC846DBB9DA8B97BCB4E1B /* KIFSystemTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 677EFD77558EFB013D0637E1C5CBB78B /* KIFSystemTestActor.m */; };
-		130B735244567027BD23672E6DD03AD8 /* UIView+VOKCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = D2464B29E90357A61F6E82E61A349E72 /* UIView+VOKCircle.m */; };
-		1A64AF947B7079FD5F5D383C29FEFE99 /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */; };
-		1BAF1A82610C6A7EA23CEDF1AD9B4CE1 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */; };
-		1E224705D276B60D3725B992F029097D /* NSException-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 816653EBF4A7423D28A018E4CECB3CAB /* NSException-KIFAdditions.m */; };
-		22D7B75B2096C2821DC84666F17AA2BC /* KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 6ECC6C36A1FE4487BD6BB7DB0118ED92 /* KIF.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		238A06359C710C7BC1E8E1C2617BB689 /* VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 503B1DA7882CF4FC214BA50FA5C81381 /* VOKUtilities-dummy.m */; };
-		23AF6569C990137FB663D722C1F29C1C /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */; };
-		24527F943882460B0EE1961DCC87B42F /* UIScrollView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 42A1B7608BADE45C28DD7DF41F4381F4 /* UIScrollView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		247878FCFB67096A63ADBB772756140A /* NSBundle-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 227D2CB3CE006DBA8987F570E24E27BB /* NSBundle-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		27B114C6E5EE0D738339C91F390218DA /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2927B94469FA6A772BE96417BBDB6BEC /* UIView+VOKCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 20A4CD7B7064BEA07E50E56D65982CDB /* UIView+VOKCircle.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2B55E3658B4CF1E821AEC47ACE449CF2 /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194EF860C6A8E7FF250F4610C226C53C /* CollectionExtensions.swift */; };
-		2BAC762956CAA21254B8D5F2EC9D7B3E /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2380DEE445F849E6502C0B33E5D53DB2 /* UIColor+VOKAL.m */; };
-		2D59D4118E2B4FDD9AB45B3BA5E90444 /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */; };
-		3259FDE0D6F1C166728055A875AB7F7A /* UIView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 389BBB72F897155429AF6867B03B6F0F /* UIView-KIFAdditions.m */; };
-		32FA8827E701B904829F5C5F88161B25 /* UIPageControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597EC2B7AF0298EF0982727A230E0C41 /* UIPageControlExtensions.swift */; };
-		338FA3D7A7C0397F2DF282D7461C9E44 /* UIView-Debugging.m in Sources */ = {isa = PBXBuildFile; fileRef = CA27611EF205EA16929BE6D445AE5A61 /* UIView-Debugging.m */; };
-		34C78670698BC8B6203F33075BCB5C40 /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 33CEE1101EE293C815A79795491E011C /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		358714A0A234CFAB3C463917D357100A /* KIFTextInputTraitsOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = 581EC5DBC1CC58700497B5E95EC97749 /* KIFTextInputTraitsOverrides.m */; };
-		35F49BC857C5BFCCF9CD9FFAE024D9F3 /* UITableViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5CC52BD45D5DC5AC5B6C7E8A20FA29 /* UITableViewExtensions.swift */; };
-		36D45731B2575D5842CF4FC09CB77A5F /* UIView+VOKDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 4301B56E2795AC2D45FFA210EA2442B7 /* UIView+VOKDebug.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		38A4539B672BDCAFD50B10183B9ABEFD /* KIFUIObject.h in Headers */ = {isa = PBXBuildFile; fileRef = B16D78479F7BC8735D9E8AFEF12E8885 /* KIFUIObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		39495A2800FE60E9ED8F70C27306BC76 /* UIScreen+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D11E27C1926EA39B462D0B767612A4E /* UIScreen+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3A7724FF69212242870A0843784D2F4D /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2380DEE445F849E6502C0B33E5D53DB2 /* UIColor+VOKAL.m */; };
-		3B8A561710C975A4192F5B91D1405086 /* CGGeometry-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D0A1AAADA3718C26BEDA11972236982D /* CGGeometry-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3D4433329A24C85601B7622C5E8177F4 /* UIEvent+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D8230543A4C9E0D5C22497D2ECDD1C7 /* UIEvent+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4108086AFFEAADC3CFC301AF58FED6D5 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4426BEF72AEBC8DC956F1DB0BAAA1E9F /* KIFUIViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 31C7A9C567311B2D0F46989E4BCCC2DD /* KIFUIViewTestActor.m */; };
-		46163911E3FF99219AFCE2D4591461C6 /* Pods-VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BFCE8813124E6E256C2262B44D13A271 /* Pods-VOKUtilities-dummy.m */; };
-		4C9B65F383FA58F1D86622D45AF8BE8B /* NSFileManager-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BDD479E47692C1EDCD90703EFACE6AD /* NSFileManager-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		4CB96E8F9061BC100585432DF7BA3BDA /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */; };
-		4CD9D16E65744DF1547C3B53BA5B863E /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */; };
-		4ECE3B3E3A3D29F9D6659D9A077F1ADC /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 33CEE1101EE293C815A79795491E011C /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5032A786CD5F9A68C1C3FD443D92BCD0 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C1F60F551AAE4A5596F0509FD12080 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */; };
-		50E6F5205C18211ED670CE7E790A892A /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		53A6CF791A083A7C71E3FC50BC52BDE8 /* VOKIBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4946387BF9A6FF2D57B19DD94B3EC7B6 /* VOKIBHelpers.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		545B8F9462BE8315EE2C0222632F4C79 /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5466F029D83D54EB8C8242796AEEB7A3 /* NSException-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 08606E64F97E62AB69E00094E99B9D9D /* NSException-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		58D78A7BE7583734693BE47FEF199053 /* UIAccessibilityElement-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 233A764FCA600EF78B3D8B3AA79EED83 /* UIAccessibilityElement-KIFAdditions.m */; };
-		591BCA1983AFBCFF525C79889819723C /* CGGeometry-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C54769710256DCE42AEA47FC1796100 /* CGGeometry-KIFAdditions.m */; };
-		5A45A0BAE7DB8985A49FE3BA3A86E384 /* UITouch-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B9F636F72FEA1335BD45123034E8F974 /* UITouch-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5BC481AF79C1C5A64B93E6FC8CD836E6 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */; };
-		5C82F8769E8F9413889F452D34A82783 /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5D5BD72B3F43A79EFCD7607CA98FCE22 /* UIView+VOKCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = 20A4CD7B7064BEA07E50E56D65982CDB /* UIView+VOKCircle.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5D77887AE928EAC6DD216A5A3648FAFE /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */; };
-		5D86601441684B34A55D8117FD9309CB /* UIView+VOKDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = F17C226BADEAE2A5853EBCA32CD45AD3 /* UIView+VOKDebug.m */; };
-		5F4508424CB3B5FEA186A14D1FC56739 /* VOKNavigationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 363780D517F2382F3736DF8DBED7B2FA /* VOKNavigationHelper.m */; };
-		5FE9936CDA1D60F5C50EC93AAEBA9570 /* ReuseIdentifiableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B079723D272DFBD587B9C07E0C155CFD /* ReuseIdentifiableView.swift */; };
-		606DBE2CA6313FF657B9B006B3742277 /* UITableView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = FEDE285DA8F712F1C29352D8E93C11EF /* UITableView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		64DC28EBD5219C841D2E24D3A81832C5 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178F01BDE8B0AA721DC702109424DE4D /* UICollectionViewExtensions.swift */; };
-		69AF46246434A86D579FE039025530C9 /* KIFUIObject.m in Sources */ = {isa = PBXBuildFile; fileRef = FDDAAE622B38279FE2EB519A3E6B7325 /* KIFUIObject.m */; };
-		69B1B81FE4F1C1705CBA7397ABB3E168 /* Pods-VOKUtilities-UITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DCDB3273BA404F6066880F97898DC7A7 /* Pods-VOKUtilities-UITests-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6A9DE7819DD98FCBB04D5A282FC162CE /* CAAnimation+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E9D4FF885B6420C53C798213CB6F667 /* CAAnimation+KIFAdditions.m */; };
-		6B53017C033AF251065E7FB989AE0DC0 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6FD34928008742068105EFDCF7700F87 /* KIFTestStepValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 985A8D1AA3BDB7813306E8821C78CF89 /* KIFTestStepValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		732CD8F6F271D11CB9A521157DC98B15 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */; };
-		74AAED2F9AF32E981FEE33700BDDC35A /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0DD57D7B392CC2A2FB7185EBB16DC0 /* UIApplicationExtensions.swift */; };
-		75EBA5CB62EAC055168BA8CF57A1FAD4 /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 2380DEE445F849E6502C0B33E5D53DB2 /* UIColor+VOKAL.m */; };
-		7884DF392661787265649F65D63E82EA /* KIFAccessibilityEnabler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8A5E046B2AFF2DC30BD3766C24CF67 /* KIFAccessibilityEnabler.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7908AF6E7AFC63996CADF5DDF58CCB84 /* Pods-VOKUtilities-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FBC33B60F1AA6C846FB94D7A54A427F /* Pods-VOKUtilities-OSX-dummy.m */; };
-		7A8451202DC962D9DB09028794F8D306 /* UIViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBAD6C3929307C1FF7FF66F93341BFB /* UIViewControllerExtensions.swift */; };
-		7AA3D0C150C3F088D06EFF6AF3AE0160 /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 42CA77640067E7DA9A0BB1FAC1D3D2B2 /* LoadableCategory.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7C667D251FEFF31C432C199B020103BF /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */; };
-		807EAD36938FB0EB73DFC67793592286 /* NSError-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D2DAC405F59379DD0C063CAD8A3DC9 /* NSError-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		80EE8320C86CEAC8BA45989DF71ADEF0 /* UIViewController+VOKKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FD426CC804F6333DAD835F63C7A1FB4 /* UIViewController+VOKKeyboard.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		870D397E3E3A1020ACEDFF18A773F04C /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */; };
-		877E40151BA3CE4DA240CDF7EF1D5E6A /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */; };
-		88C38E2BCB37DF864397E7D269E24CD6 /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 33CEE1101EE293C815A79795491E011C /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8A815713043B98E983DA0C061213FEE2 /* UINibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96765F99C5599CDB310AD2629DB4AD8F /* UINibExtensions.swift */; };
-		8AAC2D83149826670CB2C577515E96E4 /* KIFSystemTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EF1B36C66BB0936103C7E0186726C96 /* KIFSystemTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		90262600EA6E11B485E700EB06598F79 /* CALayer-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 256DEF5EE755F113C0B6270B66D49D70 /* CALayer-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		956AA4463D87C338F52E4F33BF3CBF74 /* NSFileManager-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BCDDFB59ECA27DFF764451EBDF5437B6 /* NSFileManager-KIFAdditions.m */; };
-		9637627E0EF2E1E59C707F7F3A889298 /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		96DF40488971615854221E339AD5C9F2 /* KIFUITestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 474AB8842D8050D22E17343C6A909D06 /* KIFUITestActor_Private.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		98CA2CA038CD89DE48F8B16EBC579E55 /* UIEvent+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CFBF2225597662620A87F5E89EF33B4F /* UIEvent+KIFAdditions.m */; };
-		9A5E80F240980A2C3402F5C4B8974D98 /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = CBAEF907BAE6FCDB4794D2E4E87A90F9 /* IOHIDEvent+KIF.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9B6B152612908302AF0927C7444CA4CB /* VOKIBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 4946387BF9A6FF2D57B19DD94B3EC7B6 /* VOKIBHelpers.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9B98F74182A836E0633F03F75C1A9C69 /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9E8CCDB8F5994C86A505A0CE244A0FB7 /* KIFTextInputTraitsOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 7807FF379AFCC58BC2BAD44ACD52B0A5 /* KIFTextInputTraitsOverrides.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9F054410158494CA7FCB122E128AB807 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9F3C154AE74FDB6158FCDDBDECD7058C /* UITableView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C6AF22ACF146205542E0A07D2B89742E /* UITableView-KIFAdditions.m */; };
-		9F52629011C5A6B8627A9BAED5F3E933 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		9F7E11FCF1436B5FD24577283E979B22 /* VOKEmailHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 897C087446E9AF6C97482464C4B5008E /* VOKEmailHelper.m */; };
-		A1A1A9B28AC26AB37954962D279D4F7D /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A1B42461096E3B8BAB5D309A1BFC84FC /* VOKAlertAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 65DC44433D5FFC84888264D2C5C493A7 /* VOKAlertAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A672743134D7EA5E20CF370597DE6772 /* TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B1CE26361F736C4418876CDE0D05CD /* TestExtensions.swift */; };
-		A789BCC905B8D8D8CAB4582341DB19A4 /* Pods-VOKUtilities-UITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F3A5ACE5802CD9BF2BBEB9B0E4AC5A14 /* Pods-VOKUtilities-UITests-dummy.m */; };
-		A885D6DDE124A3BD9A225575CEB41E89 /* UIView+VOKCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = D2464B29E90357A61F6E82E61A349E72 /* UIView+VOKCircle.m */; };
-		AA8168625D88368FCA12F68C413E277B /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		AC6BE6BB89B9303F1EAD6F87891AA3CF /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		AD2F77A7D7ECF28C9872EF8C489FCC31 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BF36B086797549DA57E4D1ED31D7E9A /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */; };
-		ADF4BA7A1C019BDC2B26C2DFA9BB1BB0 /* UIScrollView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 50EBBE738E53AB3C13BC526493BF7856 /* UIScrollView-KIFAdditions.m */; };
-		AF3C558B32CA94D83341AF3FCDE44F67 /* VOKUtilities-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B3144E20058BB126BDACD9FA48DA592B /* VOKUtilities-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		AFC319AC88E6E204B87A578A4DFBAD2F /* Pods-VOKUtilities-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 34899196A5B74BECD48412B2AC3B604E /* Pods-VOKUtilities-Tests-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B0A8DFEBEFD9028A8C3C19D59576C2F9 /* CALayer-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = EA19F51A2FE1C42DA25FEA6626DEE3A8 /* CALayer-KIFAdditions.m */; };
-		B1BFE1DF7C9C248E691E4870B0B342CE /* KIFUITestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B73383BCC98B3B2BE21180C9BA86AFC /* KIFUITestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B25ED186BF5F151D6A3D3D4EDB6D9A31 /* UIApplication-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4BE4C2273429BE0E4BCA0FF473F03B /* UIApplication-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B6D6289B35DFE36984BC4FB61DB3F7AF /* KIFUITestActor-ConditionalTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A456C4CD44B27EC83A46E6592B636F6 /* KIFUITestActor-ConditionalTests.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BAF37D6493B79D93C7ECB4DAEF82D381 /* UIView+VOKDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 4301B56E2795AC2D45FFA210EA2442B7 /* UIView+VOKDebug.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BCE2DE51552B5839E09F8FB6FF7EDE4C /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */; };
-		BDCA6C3F6A98F6F549D929D2984A50FB /* KIFUITestActor-ConditionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E6B821C956E09EED40CE51D0DC172B92 /* KIFUITestActor-ConditionalTests.m */; };
-		BDED08B4AABF3A7AC4FFB4122D195924 /* UIViewController+VOKKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = 97810B020D58E5EE39D7588552BF2AE6 /* UIViewController+VOKKeyboard.m */; };
-		BEF4C8898B953881598FF7BE3553AB19 /* VOKAlertHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4350F6DBBC66436788316D6FDB1A3DC1 /* VOKAlertHelper.m */; };
-		BFC01C8D7DFE8D2BB1470357E3E1F125 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C19D35CFDCB329F018E223A0B7C9E5CD /* UIWindow-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = BADD98F9AE8DA8490F2F061552CB9B60 /* UIWindow-KIFAdditions.m */; };
-		C319D7EDB69A945CE3B5DA5275EBD046 /* NSPredicate+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 32B3356984D0A9EF907D5CE19E5E5C63 /* NSPredicate+KIFAdditions.m */; };
-		C49E5B8D80835783BDBF62C7A00780A9 /* NSBundle-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = ED7DB0C3584C9A1D28AAC215655FE8F7 /* NSBundle-KIFAdditions.m */; };
-		C50599D6C20E63E13F25812A1A14BB05 /* UIAutomationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 242535CC525ECF8690A37157D9EC84A6 /* UIAutomationHelper.m */; };
-		C516A2B81347FCBF9CB1320D80DE62A4 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4692CBC3D274691C896935932772AC38 /* UIViewExtensions.swift */; };
-		C818EBD8AA3C5BDBA657AAAD94ECDD08 /* VOKUtilities-3288a73d-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 379CF77118C12B75295BD85B4CA0DFBD /* VOKUtilities-3288a73d-dummy.m */; };
-		C9A166D1F900E4E535914D0C215D68AC /* KIFTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = EDFF3811160CAB00B75A3527AC3FBA84 /* KIFTestCase.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CA38D50548CA53EA677BC82C210974F6 /* UIApplication-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AD899775892E8E32CA7347043D7435 /* UIApplication-KIFAdditions.m */; };
-		CB298CE882989EEE0681E646A5A62CE9 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034CF336EFC2AF1B9C40C2D55BC32A6E /* UIStackViewExtensions.swift */; };
-		CBD1BBD6FFE0D439E272E1B4806A5D50 /* KIFUIViewTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F8B15F21426F6555FDFEAA4A962DC0D /* KIFUIViewTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CBD899A67F601AF4CD3AFCA469A80A97 /* XCTestCase-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4835B4B663E36574CA2B5ED4A8BDDE /* XCTestCase-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CE29DA078A04020778906D0B6651CBBF /* UIView+VOKDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = F17C226BADEAE2A5853EBCA32CD45AD3 /* UIView+VOKDebug.m */; };
-		CE5EC9CE9AB6BD280AED17FC9E8E9623 /* KIFAccessibilityEnabler.m in Sources */ = {isa = PBXBuildFile; fileRef = BD670D013D07DB00D4B63F7892B966E1 /* KIFAccessibilityEnabler.m */; };
-		CEC7D337688B6C9B8B2E5F47D1878D9E /* KIFTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 75002ED02DCCD44E7C3716FF4996F7F9 /* KIFTestCase.m */; };
-		CEE2F2FB182D1701E065DD687658839C /* UIWindow-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = B882456D2FCBE9ECC9AAC357C8DB5D14 /* UIWindow-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CFA917AD4E4A400C843A8C1BFD74C915 /* UIAccessibilityElement-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = D92528D1BED762A6EB1FE90D8EB82465 /* UIAccessibilityElement-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D04DF3754052FBCB47200157866F7BC6 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D076EACCBC02C000FFD86673598E5932 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */; };
-		D35BD431D6286BA30D2EAB1C4A148B1C /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D8A874F13CDB9EBD8C3F7C355EF7A811 /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = CB93C13BA7F134BFD2C7BB64ACF8341E /* IOHIDEvent+KIF.m */; };
-		D90DBFD60CF81E84BAB63DCEFB14DB10 /* KIFUITestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A2FC0BA9CEF0B9CFFA92673B3508CE6 /* KIFUITestActor.m */; };
-		DA4AC5591C05DEA48164EE2654701871 /* UIView-Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = BE99D8916BC19E2C10B5D85E5C8F33BD /* UIView-Debugging.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DF067A7AA245854D09F51F70D8FC9A6A /* NSString+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C8FFFCEF9350F68C38CC0018FF010E3A /* NSString+KIFAdditions.m */; };
-		DF75E92E93963F8695AFC1ABAD20F223 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB05E62BE4B902B8167754B5EFAD9AD /* IntExtensions.swift */; };
-		E06011C5667EFA4ED41367586E837272 /* KIFTestStepValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = A4AA1C147142E6BC25ED4406512B202C /* KIFTestStepValidation.m */; };
-		E13A997BD27610F3AFF8A753AC81B7E3 /* VOKNavigationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = BF3473BEBB7814DE9D6C3D8DD0F0B325 /* VOKNavigationHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E15B3917B6B8D84345744F8640B82C0E /* VOKEmailHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 539B968AED0250154DD058D2A030CF2A /* VOKEmailHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E1A1FDF849F33DD9C083217280BBED7D /* Pods-VOKUtilities-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 63549E93520A77E3F09A4D1D4B312A15 /* Pods-VOKUtilities-Tests-dummy.m */; };
-		E32F063BB94CE0A5C84CA0332B8F2866 /* Pods-VOKUtilities-watchOS Extension-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A49122F02B2FCA6A27B688C6333754 /* Pods-VOKUtilities-watchOS Extension-dummy.m */; };
-		E51C1AE7DE3F7B3D7AAEA17047D00954 /* NSPredicate+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 961B37A8618299428554DA07AEAFF7E0 /* NSPredicate+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		E6128F654A02F2B76201F5640466E167 /* Pods-VOKUtilities-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B600193CBD1685C27B42E5F11EC055D6 /* Pods-VOKUtilities-tvOS-dummy.m */; };
-		E74F64513F0EA4B6CEF83BFED8FCDD88 /* NSError-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D87E653802EDDAE89AB6C5AC4519FE0C /* NSError-KIFAdditions.m */; };
-		E9300FA1BAAAB9DF9D9624809BF57530 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */; };
-		EBDE4D7762E2352ADB1D5EFEAB67D5CB /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EC0E2B80664BF8A9AAE0A297CEB56D33 /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */; };
-		ECCFD9DB93D87F5D0A8A2ADEDFE6B994 /* KIF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A35778B6C24123BBCE0BDF8374FF1785 /* KIF-dummy.m */; };
-		F05A20F4FA23663CC27FE5ACB39777BE /* NSString+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18DF79704D5B3DDC5E4C820C38A156 /* NSString+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F06ACB0015E9F1B5D348137CAE13101D /* KIFTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B527B31C8C2CD122453B890EA16CC10 /* KIFTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F07BFA220714E3FF660E0B6C6E819710 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F11CA6458070CFDFA6A69B87EC77DC01 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A61A555D420DAFD08F7B9507736FDB /* StringExtensions.swift */; };
-		F26DF92974F8BA0815A02944F507E3BA /* KIFTestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EE106EFD91F4055298ECEFA75EC708 /* KIFTestActor_Private.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F3B963CBF4E4E259DD9E874FCB15775B /* UIView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E79809103F227854DA7A9AA658EB7106 /* UIView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F3D309D9FAA8EFD8C0F062BD2C353739 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */; };
-		F3E2F56B5DC4EAA943FBA17C747605B0 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */; };
-		F4EB351F443CF358A3FBA0302C71E388 /* Pods-VOKUtilities-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 30EACFB0A4B5C9977D12C365117DC113 /* Pods-VOKUtilities-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F81F08155812B310858F0C4C3750FEAF /* VOKAlertAction.m in Sources */ = {isa = PBXBuildFile; fileRef = CE75EB0B319CCD614A56A3023437873E /* VOKAlertAction.m */; };
-		F919BA9052DD469B8E9D08EAE47DA74D /* KIFTypist.m in Sources */ = {isa = PBXBuildFile; fileRef = 81431A9D8F3C092AC4EF8AE853DD2CD2 /* KIFTypist.m */; };
-		F98F90CC8C0EA4F72270660D674811C2 /* XCTestCase-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D6EFD685C21E3A6FA8674ECE1B38BA /* XCTestCase-KIFAdditions.m */; };
-		FA8BE2AA35C4E58BA7A3CF4E711854C3 /* VOKUtilities-6aa4e1e5-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D8B0FCC063D0CD74D625A87B64684D42 /* VOKUtilities-6aa4e1e5-dummy.m */; };
-		FAD0588CDF835312E2C6B3A51BBB4054 /* VOKUtilities-d8783a65-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 33E0CEF423F7E0E1E13F20176AB3D1FA /* VOKUtilities-d8783a65-dummy.m */; };
-		FBBAF0C14047A7FCE5D75A022E89597F /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */; };
+		0611CAEE1DF6AF8AF75F92706953D7D4 /* Pods-VOKUtilities-Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C4DFE92C1AB4425A1D4CEEB44BE99B7 /* Pods-VOKUtilities-Tests-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0725F1ED5316A20F9E260C3CC74CF568 /* UIApplication-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 854F92281C52D313E09054364985B3F2 /* UIApplication-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		072B93A6C679291D15A6347CC78E34F4 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		08CA2F747CB12754C5514B666319D663 /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0ADCC2F9A01259005F64E5D255E2852B /* UITouch-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C2FEE1D005D3112F1D8D6B6745AE0787 /* UITouch-KIFAdditions.m */; };
+		0AE31ACBCCE9A2707996ADE884F666CF /* KIFUITestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7697DDA6C6D9D87F9A980B8B157429C3 /* KIFUITestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0B0971B545D372D0FA9D861BF2F8FD8C /* KIF-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D532C4FDE263005AE3E45A6159F494F9 /* KIF-dummy.m */; };
+		0C24C52EF8992C938F044B1E72CEFBE1 /* UIScrollView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A774923F68A562D8B5E73138EB25B6B3 /* UIScrollView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0C998E08632DC5ED2B50CBCBDD0F3C9B /* KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A9FC0111911F91B4B3633785129A44EF /* KIF.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0CD7D25C5E26C4F85227489B9291E5AC /* NSPredicate+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DCED89A51BE779AF73349F7BEA43C20 /* NSPredicate+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0D09EA687E3247692ECBC7F87B29C375 /* UIView+VOKCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5A993B2BA298207D16B30898FFD72A /* UIView+VOKCircle.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0E439FDA88BF2E88ACC856500FCC0944 /* UIScreen+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 538BBDDC3B252DF7264E6A4E7BFB2B21 /* UIScreen+KIFAdditions.m */; };
+		1100D998695377094CC5C38F1FEDDDC9 /* VOKNavigationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = C65C1DB7F125B6F5B0D441534484989A /* VOKNavigationHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		12ACB30E1B8E1190763C7F9AB7308A27 /* VOKAlertAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 796057F69E112F4A6754BDB9DDD99FF0 /* VOKAlertAction.m */; };
+		16894F3F6CA6A4DB6EE2F26948ADF571 /* Pods-VOKUtilities-UITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A03C585586FB4FA6F08DC89532F3B631 /* Pods-VOKUtilities-UITests-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		19606BD5186D80F8F61C1D443937F7BF /* NSError-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 83C55DA82A69EE9C2B3F21408133B34C /* NSError-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1B80D4AD271FF2E0004A81BB038CFF9F /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */; };
+		1BFAD4ADF50F22C372B1E7244313BBFA /* KIFTypist.h in Headers */ = {isa = PBXBuildFile; fileRef = 0628C7508D9B470AC9CD580FE62C1576 /* KIFTypist.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1F150BB916333DC66FC5620B6A07EDE1 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */; };
+		2182A60D0D5D40212A831F32122020FB /* CALayer-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A1F05556841D38228A95FCFD0B1AA5F /* CALayer-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		231A9B39B9757C75ABD0E00847121911 /* UIAccessibilityElement-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3418016153F5D176B9DB1E184B0DE146 /* UIAccessibilityElement-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		244E8735ACF061A67FF2D9A64ED4E115 /* UIView+VOKCircle.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5A993B2BA298207D16B30898FFD72A /* UIView+VOKCircle.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		276A03904A75CEE82AA6CF2E1820F1DD /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */; };
+		2792749A0345F5691039C59716EEC634 /* KIFTestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2110388300356A68BC40BFAAAD211494 /* KIFTestActor_Private.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		29DD15ABB74097A1C643DB7F9788A0B2 /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = FB57E366A6BA18AA1B9EA901665FE31F /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2ABF8F457882F18C212ABD87FAAC608E /* XCTestCase-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 47C1BEF536910A3CDA231CA993468D16 /* XCTestCase-KIFAdditions.m */; };
+		2B9BD8A97C3B2C65964FE148C4DA0147 /* UIAutomationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 12C0B8CD6FBBC70995B3F538FA11F845 /* UIAutomationHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2BA5F8910999DE5D86399BC362704EFC /* KIFAccessibilityEnabler.m in Sources */ = {isa = PBXBuildFile; fileRef = FF7A4A1C3FAEE1F78712067B580CFEA6 /* KIFAccessibilityEnabler.m */; };
+		2C5636799AE488754118E038194911DA /* KIFTypist.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BBCE8CB3B7020F39234BD0E66AC7730 /* KIFTypist.m */; };
+		2E4965E503AF1C511ADC6D7C6B4F9933 /* VOKAlertAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D3CC3F3D88EB64F8E42431417BF85B0 /* VOKAlertAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2F60C457213A3898FBEE96C79F99A2C5 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3010B47B6BCA1F998BC7B7177149BCA5 /* NSFileManager-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 31A8FA141DEE9ACB87524A9278292C9E /* NSFileManager-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		30FD752D90381984ADB5A87B7591E3A1 /* IOHIDEvent+KIF.m in Sources */ = {isa = PBXBuildFile; fileRef = 1733BDF9134BF6748003424ACA210E9C /* IOHIDEvent+KIF.m */; };
+		32C9E5128545F24B904518BA0DE623A0 /* Pods-VOKUtilities-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 39722953EC010F554309FCF7B10081C2 /* Pods-VOKUtilities-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		32DCDEDBDEDDB4DC666E8B7BBA3143AE /* KIFUIViewTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C31ABE1AEF1452985D106AE9FA36CA /* KIFUIViewTestActor.m */; };
+		3313734EA89F7EC8C2D94194E936B84E /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3348D6408C82798BEC8CDF5B2F85F9C4 /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		33DA2D22C985733B632AD1F5F1FF0F29 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */; };
+		372B6A052AFDF4B1D21DBCD3C46B4A1E /* KIFUITestActor-ConditionalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F3098C8519EE5AF9DDE725384502A6C1 /* KIFUITestActor-ConditionalTests.m */; };
+		3842D677146F399787E910C525F03257 /* KIFTextInputTraitsOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FDA604BF363ECAA962F96DB56F18EFD /* KIFTextInputTraitsOverrides.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		39D8A5A0C9CAD791D2141C7E6D9316F9 /* UITouch-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 21011118BE437CCF36D574B3B2CBAB58 /* UITouch-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3A605B884E8DD6B9873B71918CF3C13D /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB3644A7B680161337164688669F6FC0 /* CollectionExtensions.swift */; };
+		3A7C35D799BF06DFB5A3FCA328007752 /* UIViewController+VOKKeyboard.h in Headers */ = {isa = PBXBuildFile; fileRef = F0D2B0088F319BE6A4F253318B0A18E4 /* UIViewController+VOKKeyboard.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3E7669B7BEE459BCF0CAB8E9B7C00872 /* VOKUtilities-6aa4e1e5-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A8EB4AA5B1E3A63DDCFB03D425760363 /* VOKUtilities-6aa4e1e5-dummy.m */; };
+		3FE69190C5FB7292106727813FCDC791 /* KIFSystemTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 151518AF274D7B5563E21402EE88AB43 /* KIFSystemTestActor.m */; };
+		447B089C6AB266B5A46C611174491663 /* Pods-VOKUtilities-Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 83485C7C73EBA2B330891D183E40D562 /* Pods-VOKUtilities-Tests-dummy.m */; };
+		472B794958E1C15F5525D65652BF29B4 /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		49E895AF4486BA675262323C43815123 /* VOKNavigationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FDE3EACED5087EA9A98117116219DDE7 /* VOKNavigationHelper.m */; };
+		4E294EC294512F4B27C518056D631DB7 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ABA7F3D50FFE083C48A97A824A19FD2 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */; };
+		4E614A29676750B8E54748437AA6AC2B /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		4F621D0FE826BAF7C4779182BFC88688 /* NSException-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 47805D74E14B19FB9C15DE43425C4309 /* NSException-KIFAdditions.m */; };
+		504964211EAA4E5D3EB4C0E61B48A87A /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5150B5579B19DE3D61047E30C09CDD22 /* CAAnimation+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E2A86B6D1842B348AD599F343A7618D7 /* CAAnimation+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		56FF0F7551C55E7CDAEDE6BAC0C9F593 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */; };
+		5770CB8B5A30D803234E5492BD0913EF /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		57F9F0F4B79DBC580EE1AD13E8F09341 /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5899D4F793F4EAC4690362259A1C353F /* UIPageControlExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4377273F78EE37208EED36CDB04551 /* UIPageControlExtensions.swift */; };
+		599B300D3F770C23142920DEF270E032 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */; };
+		5A4A159F7CE7FA9BD7D3B0F7F4180464 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */; };
+		5C93115E6995B423BEE2CC5C311AD260 /* VOKIBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B73F039820602899FC064D51F35D6811 /* VOKIBHelpers.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5DF7D307F28F71CA52018740584A6296 /* UIViewController+VOKKeyboard.m in Sources */ = {isa = PBXBuildFile; fileRef = B18BB318989ED0FC237001B0C79B3385 /* UIViewController+VOKKeyboard.m */; };
+		5E7EDD5BF37E2A1542FE5788E22FA2D0 /* NSString+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D3DAFAAB509AD7639094B6BBF3CAD63 /* NSString+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		5F9CF4BF6451C918438382ACF5ABC5F7 /* Pods-VOKUtilities-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AAF268E9E4A06FAD59C701B09281816D /* Pods-VOKUtilities-OSX-dummy.m */; };
+		5FF6E4275D74E2EE4BD4B9347A26B0C4 /* CALayer-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C437DF83D3678232026C72E05C16175 /* CALayer-KIFAdditions.m */; };
+		6043A0A78D9A8B57B55EEDB875DD4E59 /* Pods-VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B41C7A039F78E5386CA01BB57828E11F /* Pods-VOKUtilities-dummy.m */; };
+		60E34AC468BCBDD642474AE58F90AFAF /* VOKAlertHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 74FE8D0865073F2272438CF9F0462D95 /* VOKAlertHelper.m */; };
+		62E1F93B0D1FFA0FCE24FD3AD8A367B7 /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */; };
+		62FBC1EBDB0E804D04C2FABB20DF8442 /* KIFTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = A8A77E97D7F4C0E843CB4B3D2991F502 /* KIFTestCase.m */; };
+		63711AFA4326196FCE75BA3E46BE97C7 /* UINibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90C65F0EE08D31A5A527BFC84DE7B23 /* UINibExtensions.swift */; };
+		65F6C045E93013601945767BB65FB59C /* UIView+VOKDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 88BF2E2E241E9005E4094F5268C7A0F4 /* UIView+VOKDebug.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		668AE6317D5CCF211BF02A144AEE9773 /* KIFTestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C73F729A165741634A0DE2025D9EC6 /* KIFTestActor.m */; };
+		6A65FF06F13304ABC3C13A5018AB760E /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D9A37EFF16CB19CD93D1B7F50C97E551 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */; };
+		6C55F29BE4925B80E048109C2D2D4410 /* UIWindow-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BB310251167202CD6D1B795EA47FBF6 /* UIWindow-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		702A2D7F05067636B5661BCBBF51E2F9 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82912D473727D116393FA848F39670 /* UICollectionViewExtensions.swift */; };
+		7274809D7B27EB21EBEDC478A30A56C8 /* IOHIDEvent+KIF.h in Headers */ = {isa = PBXBuildFile; fileRef = 8479B8B4FA726F58EF98CF614BADB1C8 /* IOHIDEvent+KIF.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		727DE9FFBECCD18CB3BFDAE193F1DB3C /* VOKEmailHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2726E5B730EC22550A4079BA18304260 /* VOKEmailHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		73EE6413F89D5DED331A26E6A3E2C07B /* NSException-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 588A84EBF6E4626961568D6F5C8510FB /* NSException-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		74A84094A7EBB52107F68DA5E70B8F5C /* UITableView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AE9FA8F23E882B18A648AB3435B8672 /* UITableView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		75DBA5C0E5B0BBB4CB4CE25F8FA92139 /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = FB57E366A6BA18AA1B9EA901665FE31F /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		78A956C47EBC2F45A0C43FE81DE75D05 /* IntExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FB67AF286433AB5C9B10556E59AD5F /* IntExtensions.swift */; };
+		8050B464C77CDC1B3627F7504E410392 /* UIView-Debugging.h in Headers */ = {isa = PBXBuildFile; fileRef = 5734BB6D663D1A0FFB3A2741FBE8CA2B /* UIView-Debugging.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		80E608893F016FF54B56E00898C53CCC /* UIEvent+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 34E174346EF518EF57D6970EB1DFD60E /* UIEvent+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		86074C27EBF7A65B7C34B3006992DDD8 /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */; };
+		86D5FD1FB7082A926BE2077D2F6FED71 /* NSError-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = A6B10EE802DA2A88FE0BF6A6A9A60F8B /* NSError-KIFAdditions.m */; };
+		86E05146CFC8D414E715550894D95DC9 /* Pods-VOKUtilities-watchOS Extension-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B3F93316D7B8B6B844EF451E989B6704 /* Pods-VOKUtilities-watchOS Extension-dummy.m */; };
+		87F588E29193866FB8E5378971E07BC0 /* KIFTestStepValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = FB44C47791414A455E267E8891F8B68B /* KIFTestStepValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		883DF04D2A5EB62376A50B3FBC09024D /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */; };
+		890C4244259B7ED1ADE33F3FAB8E85D2 /* NSString+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C52BD3A6262DE52698132DFFB4F083E2 /* NSString+KIFAdditions.m */; };
+		8C44C14D877C52CF94E44FC252BE4A8B /* UIWindow-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 28A3EF57781043041FB25E9FD58162E8 /* UIWindow-KIFAdditions.m */; };
+		8C9F53B16722BE8D752E99A25C7E9CE7 /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */; };
+		8CD1335B07EFF294001EEDDE9F164C12 /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8D6CD32E6BFD162D9146ED144069C62F /* VOKAlertHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = DD6D8F55A03EDEC06DEEA50430409CEF /* VOKAlertHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8EC68F180523EBDC9DBF6883F7863AD9 /* UIApplication-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 44AC22A5FFB2B3AEF9F5B10B38E22AA7 /* UIApplication-KIFAdditions.m */; };
+		8FAA6AB6DA9BFD572114AD156FC772A5 /* CAAnimation+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 29998B1C83CF1353932885487FA87E55 /* CAAnimation+KIFAdditions.m */; };
+		915D9C66AD5A3CC8FBDF173C64BA4FAB /* NSString+VOKValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */; };
+		92D0257F35B144281ACD0AD7D2842740 /* UIView+VOKDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = F9E791F44AE4EBA261E856425070EC4E /* UIView+VOKDebug.m */; };
+		94C099A22B94FC034BE41EAD078873CC /* KIFTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = EA6F1D3242408C554EB696E3246C5425 /* KIFTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		955E77D04F2E7A708EBA752EF3FF8130 /* UIColor+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = FB57E366A6BA18AA1B9EA901665FE31F /* UIColor+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		95BB13FA72195BD7C3CA4E7516DF8B09 /* KIFSystemTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D5FCFAF0D919A05EAF4D9CD89A5B52B /* KIFSystemTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		95FE1506A275C4977B08FD34B0E91441 /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		97382B37F557FD160C4D7DA00F96C47F /* UIScrollView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E555C713CC262BFDB7E64E16B225020 /* UIScrollView-KIFAdditions.m */; };
+		978E15EE907FC6389523D84A5ED948E0 /* XCTestCase-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2664C9DB97286469AF27C2AE5F92AE89 /* XCTestCase-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9C7044421379C91F92284994F3483558 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FCDB84A999C6239642A0C86AF5187ED /* StringExtensions.swift */; };
+		A275A4475EC2D6F9211DBAA4CAD57FEC /* UIViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFC276BAF15F4593D1193BAAB407F2E /* UIViewControllerExtensions.swift */; };
+		A279E04B38CFD7A58D4AF239204C3D73 /* UIView-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4494072B5F328320B13EA6B772126744 /* UIView-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A294247DAF0C0FC7B76F6C2B07D91AB2 /* UIView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7963DAD342448711DD63B8A5D3B341A9 /* UIView-KIFAdditions.m */; };
+		A6755A2D31E1190C0665360C7A944938 /* KIFUITestActor.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C5D0C6B5C2D53C77FDD91058B39768C /* KIFUITestActor.m */; };
+		A7ED4E297A0894439DBEFF110B9AE2A4 /* KIFUIObject.h in Headers */ = {isa = PBXBuildFile; fileRef = EEDA80244BF2D570DC3C97F1D1074C95 /* KIFUIObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A8BA5A8EDC7357BB61937F1EC0FD7801 /* VOKUtilities-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6A2DF9A51B33B59B6B04246C8225ED /* VOKUtilities-umbrella.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A95CEFFD16563829091B7BF584A60644 /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		AC588EAAD7FC663494CDFE1438D76443 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */; };
+		ACFA1EEF02C6E9C435ADCD46FA27FA05 /* KIFUIViewTestActor.h in Headers */ = {isa = PBXBuildFile; fileRef = E1F2A72BE90AF2CB286A2E020E8C865A /* KIFUIViewTestActor.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		AEAE2361860B3F768E61BF41C1318E88 /* Pods-VOKUtilities-UITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 500CF15B061A6A075A8FC952674FAFF7 /* Pods-VOKUtilities-UITests-dummy.m */; };
+		B028E4EFBBDD4836CFF6F80E55454B72 /* UITableView-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C048D3CCBA504CFBB9FD426AA9BF6ED4 /* UITableView-KIFAdditions.m */; };
+		B2427CB25D09BC7A33A783EC7EFB5F1E /* UIAutomationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 541E67506E53B7B6A3D8656FB3A3658D /* UIAutomationHelper.m */; };
+		B270ABCFF7AE3FAC209EF2077620E3E0 /* UIView+VOKDebug.m in Sources */ = {isa = PBXBuildFile; fileRef = F9E791F44AE4EBA261E856425070EC4E /* UIView+VOKDebug.m */; };
+		B5E170609650585C0A02F89941417231 /* UIView-Debugging.m in Sources */ = {isa = PBXBuildFile; fileRef = 51A35E91D78D246461515D0033E384C3 /* UIView-Debugging.m */; };
+		B7E6A8C6D565C740CB26D7B44867209E /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 65FCE101BA6858E3A0D2583689E71B9B /* LoadableCategory.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B831AA84D91D95D36263A591FB237F1F /* KIFUITestActor-ConditionalTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 17283AB5B6D087C8561522349235F7C2 /* KIFUITestActor-ConditionalTests.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B8C847ADC53B46887777AA683B9F1AEF /* VOKUtilities-3288a73d-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A5184C6661DCE28CE8100F2713E64D7 /* VOKUtilities-3288a73d-dummy.m */; };
+		BC1A9CB30616230A9A6F45AEE6FD1B33 /* KIFAccessibilityEnabler.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F07EA44B20310380C2D2AC2A0A49700 /* KIFAccessibilityEnabler.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		BDFB24D6ADF638B4CB5826D351EDBB0B /* UITableViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAE5091D65A00AC3B3055B7063E8321 /* UITableViewExtensions.swift */; };
+		BF3502FFEFD84DFFF4B50B1F47E6E023 /* Pods-VOKUtilities-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 114C99483DA0435B8B321E3BB40EFC77 /* Pods-VOKUtilities-tvOS-dummy.m */; };
+		C2E5A9C2786E7F13FF73DA343F5F6024 /* VOKEmailHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 412CE532FEF0F2981DD2B75FF5C75616 /* VOKEmailHelper.m */; };
+		C44952D6651317C81F4CDD0CB6EA8E36 /* UIApplicationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC07C3EE3A42393D975E7ED89D62FA5 /* UIApplicationExtensions.swift */; };
+		C72BCEDA013D5FE383FD8AD4809A879E /* VOKIBHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = B73F039820602899FC064D51F35D6811 /* VOKIBHelpers.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C7C7D9DBF4C9BB6255FC3B312FC1483A /* TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DCB575276AC4F1111F8358B9000C0E /* TestExtensions.swift */; };
+		CBC4D8FE5D5131AB88382B5C435490DF /* KIFTestStepValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = 50280113E17E0218C87036706C0401A1 /* KIFTestStepValidation.m */; };
+		CBC7420555649F358AFB44FFA8B7E780 /* KIFUITestActor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ACE6DF3A25F0EAEC9C796E37356B60F /* KIFUITestActor_Private.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CC0E93780F3BE70F1AEC617AC449FFAE /* UIView+VOKCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDD3A3C72F3EDD2BAF56BEE0BEEDBB1 /* UIView+VOKCircle.m */; };
+		D0CAAFC19EBE6056CE23E9EAB50C011D /* CGGeometry-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B07361F916AC43769A3654D7B05A3E7 /* CGGeometry-KIFAdditions.m */; };
+		D19407A808D8145667DFF3B1A836E64C /* CGGeometry-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = E873F20D3342C2BF27D8BAF24630D1CA /* CGGeometry-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D1C0722EEC365ECAF135C87E6F338DB9 /* VOKUtilities-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F9CE4800E3E4DE254FFC8ACA1DFBF4A /* VOKUtilities-dummy.m */; };
+		D210B1853E91CDF610CCD5B9066AC3FD /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */; };
+		D385BC7EF4C1663E3840DF195D894AD6 /* NSFileManager-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D28B0744F904025A3F206E815BF09DEE /* NSFileManager-KIFAdditions.m */; };
+		D401E25FD5ED818F050CBADC435981F9 /* UIView+VOKCircle.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FDD3A3C72F3EDD2BAF56BEE0BEEDBB1 /* UIView+VOKCircle.m */; };
+		D4731F8D605D29C076C130BF0C9BA138 /* UIEvent+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 40A6E24EE3140BA74FCC95BD24334A3A /* UIEvent+KIFAdditions.m */; };
+		D491E20BE180269B324A5B91406E6D72 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D4F50A00E987BF915F1D65145EAD5328 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70B7311518312C7CE85782D260AD7AC /* UIStackViewExtensions.swift */; };
+		D59B0E25685F3719994C09277C3838C0 /* ReuseIdentifiableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92104027C0C1133FBCB359D04728612 /* ReuseIdentifiableView.swift */; };
+		D676CC0E586D2ACF8EA0950BD0A0C5BC /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459206F7183A0580D0A974F5D993DBFF /* UIViewExtensions.swift */; };
+		D6EDB021BCEF9A49F309DD04D945E73B /* NSBundle-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 842492CB1AC0B4E5D6D7DFEE33F41FBD /* NSBundle-KIFAdditions.m */; };
+		DC552B4224AB3A4587C50384BF9FFA76 /* NSNumberFormatter+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */; };
+		DE9ED8148CB62F377BF959D2A8FD7921 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */; };
+		E07CFBD2CCFF2AC2761639D9DE2C59D3 /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */; };
+		E14827121891573EB32D02E1E4A4C126 /* VOKKeyPathHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */; };
+		E1FA3022843EEDCD4E5AA6757054C557 /* NSBundle-KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 045631F0B93D8D1FA2584AB11FB94E6F /* NSBundle-KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E54401843E2E081F23B6016BB0912350 /* VOKKeyPathHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E7F0B54ECE2BA72840C3B51D46937EC7 /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = AE27AF49804C51AA236906DA7BCE2811 /* UIColor+VOKAL.m */; };
+		E889D9F2EAF028AA7B15FC03D6460740 /* UIScreen+KIFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C90D6D5708BBCB067F6CD0F844367AD /* UIScreen+KIFAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E896CA96CB3C5AA3FCBA154AFAF7B267 /* NSPredicate+KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AF1042957774E02A681A5371EAECD1F /* NSPredicate+KIFAdditions.m */; };
+		ECD1171EF20BE11A81607D5B22456F1F /* NSNumberFormatter+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EDB5ACE558B13D8340F5E4E4674EA7F8 /* KIFTextInputTraitsOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = 5074A5530834DEC79BD80C045CE6C318 /* KIFTextInputTraitsOverrides.m */; };
+		EE6CF6FE1A7BA635436AD858F756125C /* NSString+VOKValidation.h in Headers */ = {isa = PBXBuildFile; fileRef = 35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EF12C10C9AD352B25FE29BB7A116B7D1 /* UIView+VOKDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 88BF2E2E241E9005E4094F5268C7A0F4 /* UIView+VOKDebug.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EF4D50B2328A6B2D6839AD06768B123F /* NSCalendar+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */; };
+		EFAF22C600622334AE6A73B1465588D1 /* NSPredicate+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = 09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */; };
+		F399558B771479398EF0C3C64AB1368A /* KIFUIObject.m in Sources */ = {isa = PBXBuildFile; fileRef = C1B5BE9854D2A4C595E9202CD6A00E07 /* KIFUIObject.m */; };
+		F6062079B0E8BDBCD2B05EB1EEDBF7BE /* NSPredicate+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F616C936209D5FF6F1633BAC21C15DAC /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F965F50D649F7751950B0B6EBE0A75CC /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = AE27AF49804C51AA236906DA7BCE2811 /* UIColor+VOKAL.m */; };
+		F9ED1B0D8BEDF210853D58B6B08564E0 /* NSCalendar+VOKAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FBECB8D1A53230B278F153377E6623BA /* UIColor+VOKAL.m in Sources */ = {isa = PBXBuildFile; fileRef = AE27AF49804C51AA236906DA7BCE2811 /* UIColor+VOKAL.m */; };
+		FBF80CACD8AB40962A6896237FA2DC91 /* VOKUtilities-d8783a65-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B8430C1E080ADCD9C8221E796C16536 /* VOKUtilities-d8783a65-dummy.m */; };
+		FC0BB8CFCE30B53AF07223E5A9409BD1 /* UIAccessibilityElement-KIFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 7294262BA948BA9031979409009917CE /* UIAccessibilityElement-KIFAdditions.m */; };
+		FCF0867F51700338CEBB3D0B05B01062 /* KIFTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 59293049DB68A9CFE017936B9D71F2A1 /* KIFTestCase.h */; settings = {ATTRIBUTES = (Project, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		620A6D1866AC9A8823CDE4A07A4665BE /* PBXContainerItemProxy */ = {
+		10AF388CFB1F53E6AC46B4DAC4BC0D44 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7FED5C7AEFE8FA987C032F83E89A51C3;
+			remoteGlobalIDString = 986D4576ACB401B6E7833D76875E6E80;
 			remoteInfo = "VOKUtilities-d8783a65";
 		};
-		A7B2619F408A2AAA443CA385B70E4C34 /* PBXContainerItemProxy */ = {
+		146A92EC64A2D16D357EB77DA390A795 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7BF6F455B6726E7C85743DC17CAFDD20;
+			remoteGlobalIDString = 34041BF58915475CECBF7974837EFFB1;
 			remoteInfo = VOKUtilities;
 		};
-		352C5753D09C8ACF22707DD9C4684404 /* PBXContainerItemProxy */ = {
+		34C1C52E2DD76F705DAF9DB8A7F45FD0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7FED5C7AEFE8FA987C032F83E89A51C3;
+			remoteGlobalIDString = 986D4576ACB401B6E7833D76875E6E80;
 			remoteInfo = "VOKUtilities-d8783a65";
 		};
-		3B91D3A3CD94F9D493A332F0C0D00C3A /* PBXContainerItemProxy */ = {
+		3BC49A1A89F0D000CE28185FCEDA6289 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7BF6F455B6726E7C85743DC17CAFDD20;
+			remoteGlobalIDString = 34041BF58915475CECBF7974837EFFB1;
 			remoteInfo = VOKUtilities;
 		};
-		59F6BA70798B68B868EAF8EBDE3C646A /* PBXContainerItemProxy */ = {
+		A50947147F7265C150DA9183148EA526 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 8408DDD7AD3411FF55AF08891D7BC367;
+			remoteGlobalIDString = 5F11AA50ACF05F346CDA77439859B6DA;
 			remoteInfo = "VOKUtilities-3288a73d";
 		};
-		1B03D844BC65780462DF112CE6344BF4 /* PBXContainerItemProxy */ = {
+		CAE9568E841FD5EDF926E0800BBF1012 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D66B399E182882255B61F0D42ED65BDC;
+			remoteGlobalIDString = 94DBDDEF06EFF716048EEF3645387066;
 			remoteInfo = "VOKUtilities-6aa4e1e5";
 		};
-		BCD9C31F93F147FED5C19D2C393DC0B0 /* PBXContainerItemProxy */ = {
+		CC56A34C6F6A2CA9DCF0A2D5C23D496A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 99C2EE2358EE6808D004D553CCB17A0D;
+			remoteGlobalIDString = 82B5B837E11665D1EEE2588148E3C1A7;
 			remoteInfo = KIF;
 		};
-		98954D555D99F50503D08946BD205016 /* PBXContainerItemProxy */ = {
+		CD9811DB2D790F4E05E0FA384FFECA73 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 8408DDD7AD3411FF55AF08891D7BC367;
+			remoteGlobalIDString = 5F11AA50ACF05F346CDA77439859B6DA;
 			remoteInfo = "VOKUtilities-3288a73d";
 		};
-		77F48A756E3F16ED7050358A0429B2E2 /* PBXContainerItemProxy */ = {
+		EA711C6D16CFD1610636F99FEDD19CEB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7BF6F455B6726E7C85743DC17CAFDD20;
+			remoteGlobalIDString = 34041BF58915475CECBF7974837EFFB1;
 			remoteInfo = VOKUtilities;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		034CF336EFC2AF1B9C40C2D55BC32A6E /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIStackViewExtensions.swift; path = Pod/VOKSwiftHelpers/UIStackViewExtensions.swift; sourceTree = "<group>"; };
-		08606E64F97E62AB69E00094E99B9D9D /* NSException-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSException-KIFAdditions.h"; path = "Additions/NSException-KIFAdditions.h"; sourceTree = "<group>"; };
-		0B527B31C8C2CD122453B890EA16CC10 /* KIFTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestActor.h; path = Classes/KIFTestActor.h; sourceTree = "<group>"; };
-		0BA9E8381AD94FC457CA0FE358F99BAC /* libPods-VOKUtilities-watchOS Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-watchOS Extension.a"; path = "libPods-VOKUtilities-watchOS Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+VOKAL.m"; path = "Pod/NSPredicate+VOKAL/NSPredicate+VOKAL.m"; sourceTree = "<group>"; };
-		0EF5C3FEB1E5D96EC3D465DC08AF03E0 /* libPods-VOKUtilities-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-OSX.a"; path = "libPods-VOKUtilities-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1169221C7B97C2DAFB2BBCFFA16DF5BC /* KIFTypist.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTypist.h; path = Classes/KIFTypist.h; sourceTree = "<group>"; };
-		13B07AA527C974F3D6DF671BAF5F0800 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-watchOS Extension.release.xcconfig"; sourceTree = "<group>"; };
-		13E8F743E7B20474C0FC3B5DAB277F35 /* VOKUtilities-6aa4e1e5.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-6aa4e1e5.xcconfig"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5.xcconfig"; sourceTree = "<group>"; };
-		178F01BDE8B0AA721DC702109424DE4D /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UICollectionViewExtensions.swift; path = Pod/VOKSwiftHelpers/UICollectionViewExtensions.swift; sourceTree = "<group>"; };
-		194EF860C6A8E7FF250F4610C226C53C /* CollectionExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CollectionExtensions.swift; path = Pod/VOKSwiftHelpers/CollectionExtensions.swift; sourceTree = "<group>"; };
-		1A4BE4C2273429BE0E4BCA0FF473F03B /* UIApplication-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIApplication-KIFAdditions.h"; path = "Additions/UIApplication-KIFAdditions.h"; sourceTree = "<group>"; };
-		1BF36B086797549DA57E4D1ED31D7E9A /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m"; sourceTree = "<group>"; };
-		1C54769710256DCE42AEA47FC1796100 /* CGGeometry-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CGGeometry-KIFAdditions.m"; path = "Additions/CGGeometry-KIFAdditions.m"; sourceTree = "<group>"; };
-		1DA0DBDAC8F6E17E4219EC784294DE16 /* libVOKUtilities-3288a73d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-3288a73d.a"; path = "libVOKUtilities-3288a73d.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1DA5CD3CB63E36161B8B3F7D2AE992D4 /* CAAnimation+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CAAnimation+KIFAdditions.h"; path = "Additions/CAAnimation+KIFAdditions.h"; sourceTree = "<group>"; };
-		1EA2E4CE4A681ADC33B94043FB65AEE7 /* libPods-VOKUtilities-OSX-Tests-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-OSX-Tests-OSX.a"; path = "libPods-VOKUtilities-OSX-Tests-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2027DDAB90D2F6D9748A850FF1468A8B /* libPods-VOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities.a"; path = "libPods-VOKUtilities.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		20A4CD7B7064BEA07E50E56D65982CDB /* UIView+VOKCircle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+VOKCircle.h"; path = "Pod/UIView+VOKCircle/UIView+VOKCircle.h"; sourceTree = "<group>"; };
-		227D2CB3CE006DBA8987F570E24E27BB /* NSBundle-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSBundle-KIFAdditions.h"; path = "Additions/NSBundle-KIFAdditions.h"; sourceTree = "<group>"; };
-		233A764FCA600EF78B3D8B3AA79EED83 /* UIAccessibilityElement-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAccessibilityElement-KIFAdditions.m"; path = "Additions/UIAccessibilityElement-KIFAdditions.m"; sourceTree = "<group>"; };
-		2380DEE445F849E6502C0B33E5D53DB2 /* UIColor+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIColor+VOKAL.m"; path = "Pod/UIColor+VOKAL/UIColor+VOKAL.m"; sourceTree = "<group>"; };
-		242535CC525ECF8690A37157D9EC84A6 /* UIAutomationHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UIAutomationHelper.m; path = Classes/UIAutomationHelper.m; sourceTree = "<group>"; };
-		256DEF5EE755F113C0B6270B66D49D70 /* CALayer-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CALayer-KIFAdditions.h"; path = "Additions/CALayer-KIFAdditions.h"; sourceTree = "<group>"; };
-		28DFE8D097100F6E801FA545A2D271CC /* Pods-VOKUtilities-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
-		2B73383BCC98B3B2BE21180C9BA86AFC /* KIFUITestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUITestActor.h; path = Classes/KIFUITestActor.h; sourceTree = "<group>"; };
-		2C4570663FACBCC2F9F9254A30F2B6E2 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
-		2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
-		2EF1B36C66BB0936103C7E0186726C96 /* KIFSystemTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFSystemTestActor.h; path = Classes/KIFSystemTestActor.h; sourceTree = "<group>"; };
-		30EACFB0A4B5C9977D12C365117DC113 /* Pods-VOKUtilities-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-umbrella.h"; sourceTree = "<group>"; };
-		31C7A9C567311B2D0F46989E4BCCC2DD /* KIFUIViewTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUIViewTestActor.m; path = Classes/KIFUIViewTestActor.m; sourceTree = "<group>"; };
-		32B3356984D0A9EF907D5CE19E5E5C63 /* NSPredicate+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+KIFAdditions.m"; path = "Additions/NSPredicate+KIFAdditions.m"; sourceTree = "<group>"; };
-		33CEE1101EE293C815A79795491E011C /* UIColor+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIColor+VOKAL.h"; path = "Pod/UIColor+VOKAL/UIColor+VOKAL.h"; sourceTree = "<group>"; };
-		33E0CEF423F7E0E1E13F20176AB3D1FA /* VOKUtilities-d8783a65-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-d8783a65-dummy.m"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65-dummy.m"; sourceTree = "<group>"; };
-		34899196A5B74BECD48412B2AC3B604E /* Pods-VOKUtilities-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-Tests-umbrella.h"; sourceTree = "<group>"; };
-		363780D517F2382F3736DF8DBED7B2FA /* VOKNavigationHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKNavigationHelper.m; path = Pod/VOKNavigationHelper/VOKNavigationHelper.m; sourceTree = "<group>"; };
-		377FB8124253238FE62A2FCD52DF4A28 /* VOKAlertHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKAlertHelper.h; path = Pod/VOKAlertHelper/VOKAlertHelper.h; sourceTree = "<group>"; };
-		379CF77118C12B75295BD85B4CA0DFBD /* VOKUtilities-3288a73d-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-3288a73d-dummy.m"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d-dummy.m"; sourceTree = "<group>"; };
-		389BBB72F897155429AF6867B03B6F0F /* UIView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView-KIFAdditions.m"; path = "Additions/UIView-KIFAdditions.m"; sourceTree = "<group>"; };
-		3CBAD6C3929307C1FF7FF66F93341BFB /* UIViewControllerExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIViewControllerExtensions.swift; path = Pod/VOKSwiftHelpers/UIViewControllerExtensions.swift; sourceTree = "<group>"; };
-		3FF9C68007F56397C29669B0F2391B52 /* VOKUtilities.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = VOKUtilities.modulemap; sourceTree = "<group>"; };
-		4135034912B7B6A288847A7BEC3002ED /* Pods-VOKUtilities-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities-Tests.modulemap"; sourceTree = "<group>"; };
-		42A1B7608BADE45C28DD7DF41F4381F4 /* UIScrollView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIScrollView-KIFAdditions.h"; path = "Additions/UIScrollView-KIFAdditions.h"; sourceTree = "<group>"; };
-		42A88C6B5E103F45264640EA6C6FCA1E /* Pods-VOKUtilities-UITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-UITests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		42CA77640067E7DA9A0BB1FAC1D3D2B2 /* LoadableCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LoadableCategory.h; path = Additions/LoadableCategory.h; sourceTree = "<group>"; };
-		4301B56E2795AC2D45FFA210EA2442B7 /* UIView+VOKDebug.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+VOKDebug.h"; path = "Pod/UIView+VOKDebug/UIView+VOKDebug.h"; sourceTree = "<group>"; };
-		4350F6DBBC66436788316D6FDB1A3DC1 /* VOKAlertHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKAlertHelper.m; path = Pod/VOKAlertHelper/VOKAlertHelper.m; sourceTree = "<group>"; };
-		435A7641D2D4A7EC508000A860AB876E /* Pods-VOKUtilities-watchOS Extension-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-watchOS Extension-acknowledgements.plist"; sourceTree = "<group>"; };
-		44129A44AD5306FC1A42BF9A24A253EB /* Pods-VOKUtilities-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4514C29AB56683D41FF3BB3439449241 /* Pods-VOKUtilities-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4692CBC3D274691C896935932772AC38 /* UIViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIViewExtensions.swift; path = Pod/VOKSwiftHelpers/UIViewExtensions.swift; sourceTree = "<group>"; };
-		474AB8842D8050D22E17343C6A909D06 /* KIFUITestActor_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUITestActor_Private.h; path = Classes/KIFUITestActor_Private.h; sourceTree = "<group>"; };
-		485C9F17FB14C43CB2B71C519FEF526A /* libPods-VOKUtilities-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-tvOS.a"; path = "libPods-VOKUtilities-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4946387BF9A6FF2D57B19DD94B3EC7B6 /* VOKIBHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKIBHelpers.h; path = Pod/VOKIBHelpers/VOKIBHelpers.h; sourceTree = "<group>"; };
-		4A2FC0BA9CEF0B9CFFA92673B3508CE6 /* KIFUITestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUITestActor.m; path = Classes/KIFUITestActor.m; sourceTree = "<group>"; };
-		4C1F449780836CAF00C32D235EFA8B91 /* VOKUtilities-6aa4e1e5-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-6aa4e1e5-prefix.pch"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5-prefix.pch"; sourceTree = "<group>"; };
-		4F2DD0BCC66E54C89AB77D98895D8DE8 /* VOKUtilities-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-prefix.pch"; sourceTree = "<group>"; };
-		4F604B77E5AD75277748014CD9F9707D /* Pods-VOKUtilities-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4F8D05296274DEBA7632AEDF222F5004 /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
-		503B1DA7882CF4FC214BA50FA5C81381 /* VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-dummy.m"; sourceTree = "<group>"; };
-		5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNumberFormatter+VOKAL.h"; path = "Pod/NSNumberFormatter+VOKAL/NSNumberFormatter+VOKAL.h"; sourceTree = "<group>"; };
-		50EBBE738E53AB3C13BC526493BF7856 /* UIScrollView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIScrollView-KIFAdditions.m"; path = "Additions/UIScrollView-KIFAdditions.m"; sourceTree = "<group>"; };
-		517ED2C363C638C9C87EA07B44DAD95E /* KIFTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestActor.m; path = Classes/KIFTestActor.m; sourceTree = "<group>"; };
-		539B968AED0250154DD058D2A030CF2A /* VOKEmailHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKEmailHelper.h; path = Pod/VOKEmailHelper/VOKEmailHelper.h; sourceTree = "<group>"; };
-		579E47755F2232EABA83A095AC14CD4F /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig"; sourceTree = "<group>"; };
-		57A61A555D420DAFD08F7B9507736FDB /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringExtensions.swift; path = Pod/VOKSwiftHelpers/StringExtensions.swift; sourceTree = "<group>"; };
-		581EC5DBC1CC58700497B5E95EC97749 /* KIFTextInputTraitsOverrides.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTextInputTraitsOverrides.m; path = Classes/KIFTextInputTraitsOverrides.m; sourceTree = "<group>"; };
-		597EC2B7AF0298EF0982727A230E0C41 /* UIPageControlExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIPageControlExtensions.swift; path = Pod/VOKSwiftHelpers/UIPageControlExtensions.swift; sourceTree = "<group>"; };
-		5AB028AA13C5B05486B99715DE144FA1 /* libVOKUtilities-6aa4e1e5.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-6aa4e1e5.a"; path = "libVOKUtilities-6aa4e1e5.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5B6F3052431F469A793BE88E4C436B0E /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		5F7BD544026C63EB5FEC143B6C688B86 /* VOKUtilities.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VOKUtilities.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+VOKValidation.m"; path = "Pod/NSString+VOKValidation/NSString+VOKValidation.m"; sourceTree = "<group>"; };
-		5F8B15F21426F6555FDFEAA4A962DC0D /* KIFUIViewTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUIViewTestActor.h; path = Classes/KIFUIViewTestActor.h; sourceTree = "<group>"; };
-		5FB06D11E197EF0BDC986163FDFD5DAE /* UITouch-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITouch-KIFAdditions.m"; path = "Additions/UITouch-KIFAdditions.m"; sourceTree = "<group>"; };
-		63549E93520A77E3F09A4D1D4B312A15 /* Pods-VOKUtilities-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-Tests-dummy.m"; sourceTree = "<group>"; };
-		64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSCalendar+VOKAL.m"; path = "Pod/NSCalendar+VOKAL/NSCalendar+VOKAL.m"; sourceTree = "<group>"; };
-		64DD439F1A6E7228733309C3C4B2F0F1 /* Pods-VOKUtilities-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		65DC44433D5FFC84888264D2C5C493A7 /* VOKAlertAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKAlertAction.h; path = Pod/VOKAlertHelper/VOKAlertAction.h; sourceTree = "<group>"; };
-		677EFD77558EFB013D0637E1C5CBB78B /* KIFSystemTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFSystemTestActor.m; path = Classes/KIFSystemTestActor.m; sourceTree = "<group>"; };
-		6A456C4CD44B27EC83A46E6592B636F6 /* KIFUITestActor-ConditionalTests.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "KIFUITestActor-ConditionalTests.h"; path = "Classes/KIFUITestActor-ConditionalTests.h"; sourceTree = "<group>"; };
-		6D8230543A4C9E0D5C22497D2ECDD1C7 /* UIEvent+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIEvent+KIFAdditions.h"; path = "Additions/UIEvent+KIFAdditions.h"; sourceTree = "<group>"; };
-		6ECC6C36A1FE4487BD6BB7DB0118ED92 /* KIF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIF.h; path = Classes/KIF.h; sourceTree = "<group>"; };
-		6FBC33B60F1AA6C846FB94D7A54A427F /* Pods-VOKUtilities-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-OSX-dummy.m"; sourceTree = "<group>"; };
-		6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSCalendar+VOKAL.h"; path = "Pod/NSCalendar+VOKAL/NSCalendar+VOKAL.h"; sourceTree = "<group>"; };
-		72F5DB8C343D2FD7F7CEFD948C7E3163 /* Pods-VOKUtilities-UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-UITests.debug.xcconfig"; sourceTree = "<group>"; };
-		75002ED02DCCD44E7C3716FF4996F7F9 /* KIFTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestCase.m; path = Classes/KIFTestCase.m; sourceTree = "<group>"; };
-		76A781B779B12B2F733B1116E68F29EB /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig"; sourceTree = "<group>"; };
-		76D7AF041DBC51EC3B274785061F54D4 /* Pods-VOKUtilities-UITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-UITests-acknowledgements.plist"; sourceTree = "<group>"; };
-		7807FF379AFCC58BC2BAD44ACD52B0A5 /* KIFTextInputTraitsOverrides.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTextInputTraitsOverrides.h; path = Classes/KIFTextInputTraitsOverrides.h; sourceTree = "<group>"; };
-		7B8A5E046B2AFF2DC30BD3766C24CF67 /* KIFAccessibilityEnabler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFAccessibilityEnabler.h; path = Classes/KIFAccessibilityEnabler.h; sourceTree = "<group>"; };
-		7BE35F55E952595F1F570BE22C10323A /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-watchOS Extension.debug.xcconfig"; sourceTree = "<group>"; };
-		7E4835B4B663E36574CA2B5ED4A8BDDE /* XCTestCase-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase-KIFAdditions.h"; path = "Additions/XCTestCase-KIFAdditions.h"; sourceTree = "<group>"; };
-		7FD426CC804F6333DAD835F63C7A1FB4 /* UIViewController+VOKKeyboard.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+VOKKeyboard.h"; path = "Pod/UIViewController+VOKKeyboard/UIViewController+VOKKeyboard.h"; sourceTree = "<group>"; };
-		81431A9D8F3C092AC4EF8AE853DD2CD2 /* KIFTypist.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTypist.m; path = Classes/KIFTypist.m; sourceTree = "<group>"; };
-		816653EBF4A7423D28A018E4CECB3CAB /* NSException-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSException-KIFAdditions.m"; path = "Additions/NSException-KIFAdditions.m"; sourceTree = "<group>"; };
-		83A42E026B8EBFE55A19EEF37B0BE90B /* Pods-VOKUtilities-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		84DC51BF57AF57827E9A253D63707FF0 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		86EE106EFD91F4055298ECEFA75EC708 /* KIFTestActor_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestActor_Private.h; path = Classes/KIFTestActor_Private.h; sourceTree = "<group>"; };
-		875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
-		87B124C56F34AB0239E22F12FC1E1A81 /* Pods-VOKUtilities-UITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities-UITests.modulemap"; sourceTree = "<group>"; };
-		897C087446E9AF6C97482464C4B5008E /* VOKEmailHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKEmailHelper.m; path = Pod/VOKEmailHelper/VOKEmailHelper.m; sourceTree = "<group>"; };
-		89D2DAC405F59379DD0C063CAD8A3DC9 /* NSError-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError-KIFAdditions.h"; path = "Additions/NSError-KIFAdditions.h"; sourceTree = "<group>"; };
-		8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+VOKAL.h"; path = "Pod/NSPredicate+VOKAL/NSPredicate+VOKAL.h"; sourceTree = "<group>"; };
-		8BD5F24D5CCABD1FA509BE921C30D445 /* UIScreen+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIScreen+KIFAdditions.m"; path = "Additions/UIScreen+KIFAdditions.m"; sourceTree = "<group>"; };
-		8C1A8A4CBFE4925DA8C6F9B10FE36B53 /* Pods-VOKUtilities-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		8D11E27C1926EA39B462D0B767612A4E /* UIScreen+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIScreen+KIFAdditions.h"; path = "Additions/UIScreen+KIFAdditions.h"; sourceTree = "<group>"; };
-		8DA17411F3736DF097028C4A1D4898EE /* Pods-VOKUtilities-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-Tests.release.xcconfig"; sourceTree = "<group>"; };
-		90430C18FD9F269165A5864E41E5A094 /* Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown"; sourceTree = "<group>"; };
-		93C1F60F551AAE4A5596F0509FD12080 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-OSX-Tests-OSX-dummy.m"; sourceTree = "<group>"; };
-		961B37A8618299428554DA07AEAFF7E0 /* NSPredicate+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+KIFAdditions.h"; path = "Additions/NSPredicate+KIFAdditions.h"; sourceTree = "<group>"; };
-		96765F99C5599CDB310AD2629DB4AD8F /* UINibExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UINibExtensions.swift; path = Pod/VOKSwiftHelpers/UINibExtensions.swift; sourceTree = "<group>"; };
-		97810B020D58E5EE39D7588552BF2AE6 /* UIViewController+VOKKeyboard.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+VOKKeyboard.m"; path = "Pod/UIViewController+VOKKeyboard/UIViewController+VOKKeyboard.m"; sourceTree = "<group>"; };
-		985A8D1AA3BDB7813306E8821C78CF89 /* KIFTestStepValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestStepValidation.h; path = Classes/KIFTestStepValidation.h; sourceTree = "<group>"; };
-		9A7796F972460D034535C4D684AE9906 /* Pods-VOKUtilities-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9BDD479E47692C1EDCD90703EFACE6AD /* NSFileManager-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileManager-KIFAdditions.h"; path = "Additions/NSFileManager-KIFAdditions.h"; sourceTree = "<group>"; };
-		9D2CBBE22941DDAB01BE14CA7FB26D60 /* libPods-VOKUtilities-UITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-UITests.a"; path = "libPods-VOKUtilities-UITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9E9D4FF885B6420C53C798213CB6F667 /* CAAnimation+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CAAnimation+KIFAdditions.m"; path = "Additions/CAAnimation+KIFAdditions.m"; sourceTree = "<group>"; };
-		9F9D430B6941C0F4D78D8E7C77199599 /* libKIF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libKIF.a; path = libKIF.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		A35778B6C24123BBCE0BDF8374FF1785 /* KIF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "KIF-dummy.m"; sourceTree = "<group>"; };
-		A38FF61C71733211E6DDB19385503404 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A4AA1C147142E6BC25ED4406512B202C /* KIFTestStepValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestStepValidation.m; path = Classes/KIFTestStepValidation.m; sourceTree = "<group>"; };
-		AA3F3D748D9A4FAA1553646F0F74CA75 /* UIAutomationHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UIAutomationHelper.h; path = Classes/UIAutomationHelper.h; sourceTree = "<group>"; };
-		ADAD5CD77D5A9BA700D173E34D2D1EE8 /* VOKUtilities-3288a73d-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-3288a73d-prefix.pch"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d-prefix.pch"; sourceTree = "<group>"; };
-		AE1B6395D84041FCBDBA748499FB3960 /* Pods-VOKUtilities-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		B079723D272DFBD587B9C07E0C155CFD /* ReuseIdentifiableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReuseIdentifiableView.swift; path = Pod/VOKSwiftHelpers/ReuseIdentifiableView.swift; sourceTree = "<group>"; };
-		B16D78479F7BC8735D9E8AFEF12E8885 /* KIFUIObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUIObject.h; path = Classes/KIFUIObject.h; sourceTree = "<group>"; };
-		B3144E20058BB126BDACD9FA48DA592B /* VOKUtilities-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-umbrella.h"; sourceTree = "<group>"; };
-		B5AD899775892E8E32CA7347043D7435 /* UIApplication-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication-KIFAdditions.m"; path = "Additions/UIApplication-KIFAdditions.m"; sourceTree = "<group>"; };
-		B5B1CE26361F736C4418876CDE0D05CD /* TestExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestExtensions.swift; path = Pod/VOKSwiftTestingHelpers/TestExtensions.swift; sourceTree = "<group>"; };
-		B600193CBD1685C27B42E5F11EC055D6 /* Pods-VOKUtilities-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-tvOS-dummy.m"; sourceTree = "<group>"; };
-		B882456D2FCBE9ECC9AAC357C8DB5D14 /* UIWindow-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWindow-KIFAdditions.h"; path = "Additions/UIWindow-KIFAdditions.h"; sourceTree = "<group>"; };
-		B9B799982F98E2C4B408E86C22032CBC /* Pods-VOKUtilities-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-acknowledgements.plist"; sourceTree = "<group>"; };
-		B9F636F72FEA1335BD45123034E8F974 /* UITouch-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITouch-KIFAdditions.h"; path = "Additions/UITouch-KIFAdditions.h"; sourceTree = "<group>"; };
-		BADD98F9AE8DA8490F2F061552CB9B60 /* UIWindow-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWindow-KIFAdditions.m"; path = "Additions/UIWindow-KIFAdditions.m"; sourceTree = "<group>"; };
-		BB0DD57D7B392CC2A2FB7185EBB16DC0 /* UIApplicationExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIApplicationExtensions.swift; path = Pod/VOKSwiftHelpers/UIApplicationExtensions.swift; sourceTree = "<group>"; };
-		BC1831D9749CA200885645CFCF267C6C /* libVOKUtilities-d8783a65.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-d8783a65.a"; path = "libVOKUtilities-d8783a65.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BC18DF79704D5B3DDC5E4C820C38A156 /* NSString+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+KIFAdditions.h"; path = "Additions/NSString+KIFAdditions.h"; sourceTree = "<group>"; };
-		BC8DA6D0DF596D1B39DDDFB944ACA263 /* libPods-VOKUtilities-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-Tests.a"; path = "libPods-VOKUtilities-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		BCDDFB59ECA27DFF764451EBDF5437B6 /* NSFileManager-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileManager-KIFAdditions.m"; path = "Additions/NSFileManager-KIFAdditions.m"; sourceTree = "<group>"; };
-		BD670D013D07DB00D4B63F7892B966E1 /* KIFAccessibilityEnabler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFAccessibilityEnabler.m; path = Classes/KIFAccessibilityEnabler.m; sourceTree = "<group>"; };
-		BE99D8916BC19E2C10B5D85E5C8F33BD /* UIView-Debugging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView-Debugging.h"; path = "Additions/UIView-Debugging.h"; sourceTree = "<group>"; };
-		BF3473BEBB7814DE9D6C3D8DD0F0B325 /* VOKNavigationHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKNavigationHelper.h; path = Pod/VOKNavigationHelper/VOKNavigationHelper.h; sourceTree = "<group>"; };
-		BF5CC52BD45D5DC5AC5B6C7E8A20FA29 /* UITableViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UITableViewExtensions.swift; path = Pod/VOKSwiftHelpers/UITableViewExtensions.swift; sourceTree = "<group>"; };
-		BFCE8813124E6E256C2262B44D13A271 /* Pods-VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-dummy.m"; sourceTree = "<group>"; };
-		C25FE3AA2706BFE0EAD221EF5AB8D41E /* VOKUtilities-d8783a65-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-d8783a65-prefix.pch"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65-prefix.pch"; sourceTree = "<group>"; };
-		C51FB359D45002FC335FB99246E9711B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		C6AF22ACF146205542E0A07D2B89742E /* UITableView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableView-KIFAdditions.m"; path = "Additions/UITableView-KIFAdditions.m"; sourceTree = "<group>"; };
-		C8FFFCEF9350F68C38CC0018FF010E3A /* NSString+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+KIFAdditions.m"; path = "Additions/NSString+KIFAdditions.m"; sourceTree = "<group>"; };
-		CA27611EF205EA16929BE6D445AE5A61 /* UIView-Debugging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView-Debugging.m"; path = "Additions/UIView-Debugging.m"; sourceTree = "<group>"; };
-		CB93C13BA7F134BFD2C7BB64ACF8341E /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IOHIDEvent+KIF.m"; path = "Classes/IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
-		CBAEF907BAE6FCDB4794D2E4E87A90F9 /* IOHIDEvent+KIF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IOHIDEvent+KIF.h"; path = "Classes/IOHIDEvent+KIF.h"; sourceTree = "<group>"; };
-		CD428AC25745BAAB289F14779E117C98 /* Pods-VOKUtilities-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX.debug.xcconfig"; sourceTree = "<group>"; };
-		CD9901C057035ECE56BB8051D55F0633 /* Pods-VOKUtilities.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities.release.xcconfig"; sourceTree = "<group>"; };
-		CE75EB0B319CCD614A56A3023437873E /* VOKAlertAction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKAlertAction.m; path = Pod/VOKAlertHelper/VOKAlertAction.m; sourceTree = "<group>"; };
-		CF2AF383D706834200B6F26CC65B3AF3 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		CFBF2225597662620A87F5E89EF33B4F /* UIEvent+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIEvent+KIFAdditions.m"; path = "Additions/UIEvent+KIFAdditions.m"; sourceTree = "<group>"; };
-		D0A1AAADA3718C26BEDA11972236982D /* CGGeometry-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CGGeometry-KIFAdditions.h"; path = "Additions/CGGeometry-KIFAdditions.h"; sourceTree = "<group>"; };
-		D0DEF7D991C888FA2532FC5389298272 /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-tvOS-Tests-tvOS.a"; path = "libPods-VOKUtilities-tvOS-Tests-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2464B29E90357A61F6E82E61A349E72 /* UIView+VOKCircle.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+VOKCircle.m"; path = "Pod/UIView+VOKCircle/UIView+VOKCircle.m"; sourceTree = "<group>"; };
-		D4787344129E379F792F1B4F76E67EEB /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
-		D4D0E72F17625EF3AD5416C89D4C85DF /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
-		D87BDC90E71C64BC95F0DF1CC76A4D37 /* KIF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "KIF-prefix.pch"; sourceTree = "<group>"; };
-		D87E653802EDDAE89AB6C5AC4519FE0C /* NSError-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError-KIFAdditions.m"; path = "Additions/NSError-KIFAdditions.m"; sourceTree = "<group>"; };
-		D8B0FCC063D0CD74D625A87B64684D42 /* VOKUtilities-6aa4e1e5-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-6aa4e1e5-dummy.m"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5-dummy.m"; sourceTree = "<group>"; };
-		D92528D1BED762A6EB1FE90D8EB82465 /* UIAccessibilityElement-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAccessibilityElement-KIFAdditions.h"; path = "Additions/UIAccessibilityElement-KIFAdditions.h"; sourceTree = "<group>"; };
-		D99E80F18BCD42A08B320FC4192E2FFA /* VOKUtilities-3288a73d.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-3288a73d.xcconfig"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d.xcconfig"; sourceTree = "<group>"; };
-		DCDB3273BA404F6066880F97898DC7A7 /* Pods-VOKUtilities-UITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-UITests-umbrella.h"; sourceTree = "<group>"; };
-		DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNumberFormatter+VOKAL.m"; path = "Pod/NSNumberFormatter+VOKAL/NSNumberFormatter+VOKAL.m"; sourceTree = "<group>"; };
-		DDB05E62BE4B902B8167754B5EFAD9AD /* IntExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntExtensions.swift; path = Pod/VOKSwiftHelpers/IntExtensions.swift; sourceTree = "<group>"; };
-		E0F996CCB642DC40C564B4B31F0E4938 /* Pods-VOKUtilities.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities.modulemap"; sourceTree = "<group>"; };
-		E6B821C956E09EED40CE51D0DC172B92 /* KIFUITestActor-ConditionalTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "KIFUITestActor-ConditionalTests.m"; path = "Classes/KIFUITestActor-ConditionalTests.m"; sourceTree = "<group>"; };
-		E702990E1D564EED03C1C1F7FC2F4926 /* Pods-VOKUtilities-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX.release.xcconfig"; sourceTree = "<group>"; };
-		E79809103F227854DA7A9AA658EB7106 /* UIView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView-KIFAdditions.h"; path = "Additions/UIView-KIFAdditions.h"; sourceTree = "<group>"; };
-		E7A49122F02B2FCA6A27B688C6333754 /* Pods-VOKUtilities-watchOS Extension-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-watchOS Extension-dummy.m"; sourceTree = "<group>"; };
-		E8D6EFD685C21E3A6FA8674ECE1B38BA /* XCTestCase-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase-KIFAdditions.m"; path = "Additions/XCTestCase-KIFAdditions.m"; sourceTree = "<group>"; };
-		EA19F51A2FE1C42DA25FEA6626DEE3A8 /* CALayer-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CALayer-KIFAdditions.m"; path = "Additions/CALayer-KIFAdditions.m"; sourceTree = "<group>"; };
-		ED67C606E320E7552854220756D4CCD6 /* Pods-VOKUtilities.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities.debug.xcconfig"; sourceTree = "<group>"; };
-		ED7DB0C3584C9A1D28AAC215655FE8F7 /* NSBundle-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSBundle-KIFAdditions.m"; path = "Additions/NSBundle-KIFAdditions.m"; sourceTree = "<group>"; };
-		EDFF3811160CAB00B75A3527AC3FBA84 /* KIFTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestCase.h; path = Classes/KIFTestCase.h; sourceTree = "<group>"; };
-		EF15B543402F7F49A37C463991728D76 /* KIF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = KIF.xcconfig; sourceTree = "<group>"; };
-		F0986C9E216ADEE673E9422FE401F0E1 /* Pods-VOKUtilities-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS.release.xcconfig"; sourceTree = "<group>"; };
-		F17C226BADEAE2A5853EBCA32CD45AD3 /* UIView+VOKDebug.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+VOKDebug.m"; path = "Pod/UIView+VOKDebug/UIView+VOKDebug.m"; sourceTree = "<group>"; };
-		F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVOKUtilities.a; path = libVOKUtilities.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		F3A5ACE5802CD9BF2BBEB9B0E4AC5A14 /* Pods-VOKUtilities-UITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-UITests-dummy.m"; sourceTree = "<group>"; };
-		F66D42ACC4DFF844005E41B9E0CBC148 /* VOKUtilities.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VOKUtilities.xcconfig; sourceTree = "<group>"; };
-		F8BFCFF33D82958419B37BCA846C71B1 /* VOKUtilities-d8783a65.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-d8783a65.xcconfig"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65.xcconfig"; sourceTree = "<group>"; };
-		FAE18B5CBCA58BE2C1F5F17C91E25481 /* Pods-VOKUtilities-UITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-UITests.release.xcconfig"; sourceTree = "<group>"; };
-		FDDAAE622B38279FE2EB519A3E6B7325 /* KIFUIObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUIObject.m; path = Classes/KIFUIObject.m; sourceTree = "<group>"; };
-		FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+VOKValidation.h"; path = "Pod/NSString+VOKValidation/NSString+VOKValidation.h"; sourceTree = "<group>"; };
-		FEDE285DA8F712F1C29352D8E93C11EF /* UITableView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableView-KIFAdditions.h"; path = "Additions/UITableView-KIFAdditions.h"; sourceTree = "<group>"; };
+		0323B2E7B3935FD08D198AD047C5EE5F /* libPods-VOKUtilities-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-OSX.a"; path = "libPods-VOKUtilities-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		045631F0B93D8D1FA2584AB11FB94E6F /* NSBundle-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSBundle-KIFAdditions.h"; path = "Additions/NSBundle-KIFAdditions.h"; sourceTree = "<group>"; };
+		0517A9AC6133FD1B2804E8E5E6824807 /* Pods-VOKUtilities-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		0628C7508D9B470AC9CD580FE62C1576 /* KIFTypist.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTypist.h; path = Classes/KIFTypist.h; sourceTree = "<group>"; };
+		0740D885F6BF96D914FE155B29BD9254 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
+		09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+VOKAL.m"; path = "Pod/NSPredicate+VOKAL/NSPredicate+VOKAL.m"; sourceTree = "<group>"; };
+		0BBCE8CB3B7020F39234BD0E66AC7730 /* KIFTypist.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTypist.m; path = Classes/KIFTypist.m; sourceTree = "<group>"; };
+		0CB62E3C55E68B91C2F902844B260D2E /* Pods-VOKUtilities-UITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-UITests-acknowledgements.plist"; sourceTree = "<group>"; };
+		0D5FCFAF0D919A05EAF4D9CD89A5B52B /* KIFSystemTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFSystemTestActor.h; path = Classes/KIFSystemTestActor.h; sourceTree = "<group>"; };
+		1027FFC49594806C3E6A65317C3D1405 /* VOKUtilities.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = VOKUtilities.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		114C99483DA0435B8B321E3BB40EFC77 /* Pods-VOKUtilities-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-tvOS-dummy.m"; sourceTree = "<group>"; };
+		122F88ABE31C9661F41BF8C723518A9B /* Pods-VOKUtilities-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		12C0B8CD6FBBC70995B3F538FA11F845 /* UIAutomationHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UIAutomationHelper.h; path = Classes/UIAutomationHelper.h; sourceTree = "<group>"; };
+		1370D45A652E01B5A12123D70C2F6109 /* Pods-VOKUtilities-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		151518AF274D7B5563E21402EE88AB43 /* KIFSystemTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFSystemTestActor.m; path = Classes/KIFSystemTestActor.m; sourceTree = "<group>"; };
+		16ACF05D99F205680763E44C25073327 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		17283AB5B6D087C8561522349235F7C2 /* KIFUITestActor-ConditionalTests.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "KIFUITestActor-ConditionalTests.h"; path = "Classes/KIFUITestActor-ConditionalTests.h"; sourceTree = "<group>"; };
+		1733BDF9134BF6748003424ACA210E9C /* IOHIDEvent+KIF.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "IOHIDEvent+KIF.m"; path = "Classes/IOHIDEvent+KIF.m"; sourceTree = "<group>"; };
+		18951E6700E59990FC623EA7184983D9 /* Pods-VOKUtilities-UITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities-UITests.modulemap"; sourceTree = "<group>"; };
+		1983AB640BD3B786ED8CEF6ABEE7055F /* Pods-VOKUtilities-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSCalendar+VOKAL.m"; path = "Pod/NSCalendar+VOKAL/NSCalendar+VOKAL.m"; sourceTree = "<group>"; };
+		1A9B9EF968E0FF4C24C53B00C2F1B574 /* Pods-VOKUtilities-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-Tests.release.xcconfig"; sourceTree = "<group>"; };
+		1BADF65E39AFB8DA21FE55349C987D8D /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
+		1D3DAFAAB509AD7639094B6BBF3CAD63 /* NSString+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+KIFAdditions.h"; path = "Additions/NSString+KIFAdditions.h"; sourceTree = "<group>"; };
+		1DCED89A51BE779AF73349F7BEA43C20 /* NSPredicate+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+KIFAdditions.h"; path = "Additions/NSPredicate+KIFAdditions.h"; sourceTree = "<group>"; };
+		1EC901FB7E6B1006E52A354BCE0C78E8 /* Pods-VOKUtilities-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-acknowledgements.plist"; sourceTree = "<group>"; };
+		1FCDB84A999C6239642A0C86AF5187ED /* StringExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StringExtensions.swift; path = Pod/VOKSwiftHelpers/StringExtensions.swift; sourceTree = "<group>"; };
+		21011118BE437CCF36D574B3B2CBAB58 /* UITouch-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITouch-KIFAdditions.h"; path = "Additions/UITouch-KIFAdditions.h"; sourceTree = "<group>"; };
+		2110388300356A68BC40BFAAAD211494 /* KIFTestActor_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestActor_Private.h; path = Classes/KIFTestActor_Private.h; sourceTree = "<group>"; };
+		21DCB575276AC4F1111F8358B9000C0E /* TestExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestExtensions.swift; path = Pod/VOKSwiftTestingHelpers/TestExtensions.swift; sourceTree = "<group>"; };
+		2664C9DB97286469AF27C2AE5F92AE89 /* XCTestCase-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase-KIFAdditions.h"; path = "Additions/XCTestCase-KIFAdditions.h"; sourceTree = "<group>"; };
+		2726E5B730EC22550A4079BA18304260 /* VOKEmailHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKEmailHelper.h; path = Pod/VOKEmailHelper/VOKEmailHelper.h; sourceTree = "<group>"; };
+		28A3EF57781043041FB25E9FD58162E8 /* UIWindow-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWindow-KIFAdditions.m"; path = "Additions/UIWindow-KIFAdditions.m"; sourceTree = "<group>"; };
+		29998B1C83CF1353932885487FA87E55 /* CAAnimation+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CAAnimation+KIFAdditions.m"; path = "Additions/CAAnimation+KIFAdditions.m"; sourceTree = "<group>"; };
+		29C8F167BEDFA04DF429BC1FA428BF2B /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-tvOS-Tests-tvOS.a"; path = "libPods-VOKUtilities-tvOS-Tests-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2ACE6DF3A25F0EAEC9C796E37356B60F /* KIFUITestActor_Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUITestActor_Private.h; path = Classes/KIFUITestActor_Private.h; sourceTree = "<group>"; };
+		2C437DF83D3678232026C72E05C16175 /* CALayer-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CALayer-KIFAdditions.m"; path = "Additions/CALayer-KIFAdditions.m"; sourceTree = "<group>"; };
+		2C4DFE92C1AB4425A1D4CEEB44BE99B7 /* Pods-VOKUtilities-Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-Tests-umbrella.h"; sourceTree = "<group>"; };
+		2C5D0C6B5C2D53C77FDD91058B39768C /* KIFUITestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUITestActor.m; path = Classes/KIFUITestActor.m; sourceTree = "<group>"; };
+		2D6A2DF9A51B33B59B6B04246C8225ED /* VOKUtilities-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-umbrella.h"; sourceTree = "<group>"; };
+		2DF28D9FB0A77A7D6810DA3DA867835F /* Pods-VOKUtilities-tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS.release.xcconfig"; sourceTree = "<group>"; };
+		308B8869DF208C08C36B1785FDEE019F /* libVOKUtilities-6aa4e1e5.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-6aa4e1e5.a"; path = "libVOKUtilities-6aa4e1e5.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		31A8FA141DEE9ACB87524A9278292C9E /* NSFileManager-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSFileManager-KIFAdditions.h"; path = "Additions/NSFileManager-KIFAdditions.h"; sourceTree = "<group>"; };
+		33C31ABE1AEF1452985D106AE9FA36CA /* KIFUIViewTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUIViewTestActor.m; path = Classes/KIFUIViewTestActor.m; sourceTree = "<group>"; };
+		3418016153F5D176B9DB1E184B0DE146 /* UIAccessibilityElement-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAccessibilityElement-KIFAdditions.h"; path = "Additions/UIAccessibilityElement-KIFAdditions.h"; sourceTree = "<group>"; };
+		34223268480812C64A56BFEAE7585775 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		34E174346EF518EF57D6970EB1DFD60E /* UIEvent+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIEvent+KIFAdditions.h"; path = "Additions/UIEvent+KIFAdditions.h"; sourceTree = "<group>"; };
+		35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+VOKValidation.h"; path = "Pod/NSString+VOKValidation/NSString+VOKValidation.h"; sourceTree = "<group>"; };
+		395975096FCAF8C7B95024372C39BA80 /* VOKUtilities-3288a73d-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-3288a73d-prefix.pch"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d-prefix.pch"; sourceTree = "<group>"; };
+		39722953EC010F554309FCF7B10081C2 /* Pods-VOKUtilities-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-umbrella.h"; sourceTree = "<group>"; };
+		39FB67AF286433AB5C9B10556E59AD5F /* IntExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntExtensions.swift; path = Pod/VOKSwiftHelpers/IntExtensions.swift; sourceTree = "<group>"; };
+		3ABA7F3D50FFE083C48A97A824A19FD2 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m"; sourceTree = "<group>"; };
+		3BC07C3EE3A42393D975E7ED89D62FA5 /* UIApplicationExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIApplicationExtensions.swift; path = Pod/VOKSwiftHelpers/UIApplicationExtensions.swift; sourceTree = "<group>"; };
+		3D3CC3F3D88EB64F8E42431417BF85B0 /* VOKAlertAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKAlertAction.h; path = Pod/VOKAlertHelper/VOKAlertAction.h; sourceTree = "<group>"; };
+		40A6E24EE3140BA74FCC95BD24334A3A /* UIEvent+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIEvent+KIFAdditions.m"; path = "Additions/UIEvent+KIFAdditions.m"; sourceTree = "<group>"; };
+		412CE532FEF0F2981DD2B75FF5C75616 /* VOKEmailHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKEmailHelper.m; path = Pod/VOKEmailHelper/VOKEmailHelper.m; sourceTree = "<group>"; };
+		4494072B5F328320B13EA6B772126744 /* UIView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView-KIFAdditions.h"; path = "Additions/UIView-KIFAdditions.h"; sourceTree = "<group>"; };
+		44AC22A5FFB2B3AEF9F5B10B38E22AA7 /* UIApplication-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIApplication-KIFAdditions.m"; path = "Additions/UIApplication-KIFAdditions.m"; sourceTree = "<group>"; };
+		459206F7183A0580D0A974F5D993DBFF /* UIViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIViewExtensions.swift; path = Pod/VOKSwiftHelpers/UIViewExtensions.swift; sourceTree = "<group>"; };
+		46D82AA661E046BBDC5AFC9FAD973AEC /* VOKUtilities-d8783a65-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-d8783a65-prefix.pch"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65-prefix.pch"; sourceTree = "<group>"; };
+		477C6FDE8319E8DE89215F370869DC4E /* Pods-VOKUtilities-UITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-UITests.release.xcconfig"; sourceTree = "<group>"; };
+		47805D74E14B19FB9C15DE43425C4309 /* NSException-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSException-KIFAdditions.m"; path = "Additions/NSException-KIFAdditions.m"; sourceTree = "<group>"; };
+		47C1BEF536910A3CDA231CA993468D16 /* XCTestCase-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase-KIFAdditions.m"; path = "Additions/XCTestCase-KIFAdditions.m"; sourceTree = "<group>"; };
+		4FDA604BF363ECAA962F96DB56F18EFD /* KIFTextInputTraitsOverrides.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTextInputTraitsOverrides.h; path = Classes/KIFTextInputTraitsOverrides.h; sourceTree = "<group>"; };
+		500CF15B061A6A075A8FC952674FAFF7 /* Pods-VOKUtilities-UITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-UITests-dummy.m"; sourceTree = "<group>"; };
+		50280113E17E0218C87036706C0401A1 /* KIFTestStepValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestStepValidation.m; path = Classes/KIFTestStepValidation.m; sourceTree = "<group>"; };
+		5042A0A09414A01B7F161560893592AA /* Pods-VOKUtilities.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities.release.xcconfig"; sourceTree = "<group>"; };
+		5074A5530834DEC79BD80C045CE6C318 /* KIFTextInputTraitsOverrides.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTextInputTraitsOverrides.m; path = Classes/KIFTextInputTraitsOverrides.m; sourceTree = "<group>"; };
+		51A35E91D78D246461515D0033E384C3 /* UIView-Debugging.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView-Debugging.m"; path = "Additions/UIView-Debugging.m"; sourceTree = "<group>"; };
+		535DEC30191070958A7B52EFA68E623D /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		538BBDDC3B252DF7264E6A4E7BFB2B21 /* UIScreen+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIScreen+KIFAdditions.m"; path = "Additions/UIScreen+KIFAdditions.m"; sourceTree = "<group>"; };
+		541E67506E53B7B6A3D8656FB3A3658D /* UIAutomationHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UIAutomationHelper.m; path = Classes/UIAutomationHelper.m; sourceTree = "<group>"; };
+		5734BB6D663D1A0FFB3A2741FBE8CA2B /* UIView-Debugging.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView-Debugging.h"; path = "Additions/UIView-Debugging.h"; sourceTree = "<group>"; };
+		574C008DD62A18FBCD1B780A1D2F0185 /* Pods-VOKUtilities-Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities-Tests.modulemap"; sourceTree = "<group>"; };
+		588A84EBF6E4626961568D6F5C8510FB /* NSException-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSException-KIFAdditions.h"; path = "Additions/NSException-KIFAdditions.h"; sourceTree = "<group>"; };
+		58B99DC0D6F954E7E2947E02D026A960 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-watchOS Extension.release.xcconfig"; sourceTree = "<group>"; };
+		59293049DB68A9CFE017936B9D71F2A1 /* KIFTestCase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestCase.h; path = Classes/KIFTestCase.h; sourceTree = "<group>"; };
+		5A5184C6661DCE28CE8100F2713E64D7 /* VOKUtilities-3288a73d-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-3288a73d-dummy.m"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d-dummy.m"; sourceTree = "<group>"; };
+		5AE9FA8F23E882B18A648AB3435B8672 /* UITableView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UITableView-KIFAdditions.h"; path = "Additions/UITableView-KIFAdditions.h"; sourceTree = "<group>"; };
+		5F07EA44B20310380C2D2AC2A0A49700 /* KIFAccessibilityEnabler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFAccessibilityEnabler.h; path = Classes/KIFAccessibilityEnabler.h; sourceTree = "<group>"; };
+		5F9CE4800E3E4DE254FFC8ACA1DFBF4A /* VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VOKUtilities-dummy.m"; sourceTree = "<group>"; };
+		65FCE101BA6858E3A0D2583689E71B9B /* LoadableCategory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = LoadableCategory.h; path = Additions/LoadableCategory.h; sourceTree = "<group>"; };
+		6A1F05556841D38228A95FCFD0B1AA5F /* CALayer-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CALayer-KIFAdditions.h"; path = "Additions/CALayer-KIFAdditions.h"; sourceTree = "<group>"; };
+		6BB310251167202CD6D1B795EA47FBF6 /* UIWindow-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWindow-KIFAdditions.h"; path = "Additions/UIWindow-KIFAdditions.h"; sourceTree = "<group>"; };
+		6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+VOKAL.h"; path = "Pod/NSPredicate+VOKAL/NSPredicate+VOKAL.h"; sourceTree = "<group>"; };
+		6DC5BCE78DF9B83DFA827C00999804D2 /* Pods-VOKUtilities-tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		6E555C713CC262BFDB7E64E16B225020 /* UIScrollView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIScrollView-KIFAdditions.m"; path = "Additions/UIScrollView-KIFAdditions.m"; sourceTree = "<group>"; };
+		7294262BA948BA9031979409009917CE /* UIAccessibilityElement-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAccessibilityElement-KIFAdditions.m"; path = "Additions/UIAccessibilityElement-KIFAdditions.m"; sourceTree = "<group>"; };
+		7379E0BB7B9148E56C92D029622AB3DE /* Pods-VOKUtilities-Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		74FE8D0865073F2272438CF9F0462D95 /* VOKAlertHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKAlertHelper.m; path = Pod/VOKAlertHelper/VOKAlertHelper.m; sourceTree = "<group>"; };
+		757DC2EBFACA2FDDD756AEAC3298FD09 /* libVOKUtilities-3288a73d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-3288a73d.a"; path = "libVOKUtilities-3288a73d.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7697DDA6C6D9D87F9A980B8B157429C3 /* KIFUITestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUITestActor.h; path = Classes/KIFUITestActor.h; sourceTree = "<group>"; };
+		796057F69E112F4A6754BDB9DDD99FF0 /* VOKAlertAction.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKAlertAction.m; path = Pod/VOKAlertHelper/VOKAlertAction.m; sourceTree = "<group>"; };
+		7963DAD342448711DD63B8A5D3B341A9 /* UIView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView-KIFAdditions.m"; path = "Additions/UIView-KIFAdditions.m"; sourceTree = "<group>"; };
+		79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKKeyPathHelper.h; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.h; sourceTree = "<group>"; };
+		7AF1042957774E02A681A5371EAECD1F /* NSPredicate+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+KIFAdditions.m"; path = "Additions/NSPredicate+KIFAdditions.m"; sourceTree = "<group>"; };
+		7B07361F916AC43769A3654D7B05A3E7 /* CGGeometry-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "CGGeometry-KIFAdditions.m"; path = "Additions/CGGeometry-KIFAdditions.m"; sourceTree = "<group>"; };
+		7C90D6D5708BBCB067F6CD0F844367AD /* UIScreen+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIScreen+KIFAdditions.h"; path = "Additions/UIScreen+KIFAdditions.h"; sourceTree = "<group>"; };
+		81A17D35F50E350E5ADA4F8213AC0ADB /* KIF.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = KIF.xcconfig; sourceTree = "<group>"; };
+		83485C7C73EBA2B330891D183E40D562 /* Pods-VOKUtilities-Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-Tests-dummy.m"; sourceTree = "<group>"; };
+		83508BC317EB0EDC6E8DA3A2F00E757A /* Pods-VOKUtilities.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-VOKUtilities.modulemap"; sourceTree = "<group>"; };
+		83C55DA82A69EE9C2B3F21408133B34C /* NSError-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSError-KIFAdditions.h"; path = "Additions/NSError-KIFAdditions.h"; sourceTree = "<group>"; };
+		842492CB1AC0B4E5D6D7DFEE33F41FBD /* NSBundle-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSBundle-KIFAdditions.m"; path = "Additions/NSBundle-KIFAdditions.m"; sourceTree = "<group>"; };
+		8450F7A572E5020573BF40FAF93D3143 /* VOKUtilities.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = VOKUtilities.modulemap; sourceTree = "<group>"; };
+		8479B8B4FA726F58EF98CF614BADB1C8 /* IOHIDEvent+KIF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "IOHIDEvent+KIF.h"; path = "Classes/IOHIDEvent+KIF.h"; sourceTree = "<group>"; };
+		854F92281C52D313E09054364985B3F2 /* UIApplication-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIApplication-KIFAdditions.h"; path = "Additions/UIApplication-KIFAdditions.h"; sourceTree = "<group>"; };
+		8800680AA42C25DA643210E051BD64C2 /* libPods-VOKUtilities-UITests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-UITests.a"; path = "libPods-VOKUtilities-UITests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		88BF2E2E241E9005E4094F5268C7A0F4 /* UIView+VOKDebug.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+VOKDebug.h"; path = "Pod/UIView+VOKDebug/UIView+VOKDebug.h"; sourceTree = "<group>"; };
+		8B8430C1E080ADCD9C8221E796C16536 /* VOKUtilities-d8783a65-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-d8783a65-dummy.m"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65-dummy.m"; sourceTree = "<group>"; };
+		8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSCalendar+VOKAL.h"; path = "Pod/NSCalendar+VOKAL/NSCalendar+VOKAL.h"; sourceTree = "<group>"; };
+		917BAEA5E6FE1ECA0EC4E03E35BEE1DA /* KIF-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "KIF-prefix.pch"; sourceTree = "<group>"; };
+		936B509B358510D3EADBF473EAA85AC2 /* libPods-VOKUtilities-OSX-Tests-OSX.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-OSX-Tests-OSX.a"; path = "libPods-VOKUtilities-OSX-Tests-OSX.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		958BC9F6D4BAAAEC382EEF1AA6C2563A /* Pods-VOKUtilities-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-acknowledgements.markdown"; sourceTree = "<group>"; };
+		96C73F729A165741634A0DE2025D9EC6 /* KIFTestActor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestActor.m; path = Classes/KIFTestActor.m; sourceTree = "<group>"; };
+		9A70988694FC02FC177D68D52C526C0D /* Pods-VOKUtilities-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
+		9A82912D473727D116393FA848F39670 /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UICollectionViewExtensions.swift; path = Pod/VOKSwiftHelpers/UICollectionViewExtensions.swift; sourceTree = "<group>"; };
+		9AAE5091D65A00AC3B3055B7063E8321 /* UITableViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UITableViewExtensions.swift; path = Pod/VOKSwiftHelpers/UITableViewExtensions.swift; sourceTree = "<group>"; };
+		9AFC276BAF15F4593D1193BAAB407F2E /* UIViewControllerExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIViewControllerExtensions.swift; path = Pod/VOKSwiftHelpers/UIViewControllerExtensions.swift; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9E4377273F78EE37208EED36CDB04551 /* UIPageControlExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIPageControlExtensions.swift; path = Pod/VOKSwiftHelpers/UIPageControlExtensions.swift; sourceTree = "<group>"; };
+		9FDD3A3C72F3EDD2BAF56BEE0BEEDBB1 /* UIView+VOKCircle.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+VOKCircle.m"; path = "Pod/UIView+VOKCircle/UIView+VOKCircle.m"; sourceTree = "<group>"; };
+		A03C585586FB4FA6F08DC89532F3B631 /* Pods-VOKUtilities-UITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-VOKUtilities-UITests-umbrella.h"; sourceTree = "<group>"; };
+		A1F46A1672C999E6E7F27CC368D40F9F /* libVOKUtilities-d8783a65.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libVOKUtilities-d8783a65.a"; path = "libVOKUtilities-d8783a65.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6B10EE802DA2A88FE0BF6A6A9A60F8B /* NSError-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSError-KIFAdditions.m"; path = "Additions/NSError-KIFAdditions.m"; sourceTree = "<group>"; };
+		A774923F68A562D8B5E73138EB25B6B3 /* UIScrollView-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIScrollView-KIFAdditions.h"; path = "Additions/UIScrollView-KIFAdditions.h"; sourceTree = "<group>"; };
+		A8A77E97D7F4C0E843CB4B3D2991F502 /* KIFTestCase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFTestCase.m; path = Classes/KIFTestCase.m; sourceTree = "<group>"; };
+		A8EB4AA5B1E3A63DDCFB03D425760363 /* VOKUtilities-6aa4e1e5-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "VOKUtilities-6aa4e1e5-dummy.m"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5-dummy.m"; sourceTree = "<group>"; };
+		A9FC0111911F91B4B3633785129A44EF /* KIF.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIF.h; path = Classes/KIF.h; sourceTree = "<group>"; };
+		AAF268E9E4A06FAD59C701B09281816D /* Pods-VOKUtilities-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-OSX-dummy.m"; sourceTree = "<group>"; };
+		AB89795847149BFD57F40652E55F4666 /* libPods-VOKUtilities-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-tvOS.a"; path = "libPods-VOKUtilities-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC85B484287AB5C191B492814CE5B59A /* libPods-VOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities.a"; path = "libPods-VOKUtilities.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE27AF49804C51AA236906DA7BCE2811 /* UIColor+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIColor+VOKAL.m"; path = "Pod/UIColor+VOKAL/UIColor+VOKAL.m"; sourceTree = "<group>"; };
+		B12F9737EFAFE8060BF767C5905FBD69 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		B18BB318989ED0FC237001B0C79B3385 /* UIViewController+VOKKeyboard.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+VOKKeyboard.m"; path = "Pod/UIViewController+VOKKeyboard/UIViewController+VOKKeyboard.m"; sourceTree = "<group>"; };
+		B29767A5C3680270E1CFAEC28527606C /* VOKUtilities.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VOKUtilities.xcconfig; sourceTree = "<group>"; };
+		B3F93316D7B8B6B844EF451E989B6704 /* Pods-VOKUtilities-watchOS Extension-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-watchOS Extension-dummy.m"; sourceTree = "<group>"; };
+		B41C7A039F78E5386CA01BB57828E11F /* Pods-VOKUtilities-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-dummy.m"; sourceTree = "<group>"; };
+		B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+VOKValidation.m"; path = "Pod/NSString+VOKValidation/NSString+VOKValidation.m"; sourceTree = "<group>"; };
+		B73F039820602899FC064D51F35D6811 /* VOKIBHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKIBHelpers.h; path = Pod/VOKIBHelpers/VOKIBHelpers.h; sourceTree = "<group>"; };
+		BA841049A5BC321DEE9BDFC72F97BB67 /* Pods-VOKUtilities-watchOS Extension-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-watchOS Extension-acknowledgements.plist"; sourceTree = "<group>"; };
+		BB61F8D7346713C87C910D82A030E7A2 /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-watchOS Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		BEFA062B53BA6DD40FCEC89CBCC19AA3 /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig"; sourceTree = "<group>"; };
+		C048D3CCBA504CFBB9FD426AA9BF6ED4 /* UITableView-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITableView-KIFAdditions.m"; path = "Additions/UITableView-KIFAdditions.m"; sourceTree = "<group>"; };
+		C1B5BE9854D2A4C595E9202CD6A00E07 /* KIFUIObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFUIObject.m; path = Classes/KIFUIObject.m; sourceTree = "<group>"; };
+		C2FEE1D005D3112F1D8D6B6745AE0787 /* UITouch-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UITouch-KIFAdditions.m"; path = "Additions/UITouch-KIFAdditions.m"; sourceTree = "<group>"; };
+		C4B495B81B1987A183CB1523CE6A95C8 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist"; sourceTree = "<group>"; };
+		C52BD3A6262DE52698132DFFB4F083E2 /* NSString+KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+KIFAdditions.m"; path = "Additions/NSString+KIFAdditions.m"; sourceTree = "<group>"; };
+		C65C1DB7F125B6F5B0D441534484989A /* VOKNavigationHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKNavigationHelper.h; path = Pod/VOKNavigationHelper/VOKNavigationHelper.h; sourceTree = "<group>"; };
+		C70B7311518312C7CE85782D260AD7AC /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UIStackViewExtensions.swift; path = Pod/VOKSwiftHelpers/UIStackViewExtensions.swift; sourceTree = "<group>"; };
+		CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKKeyPathHelper.m; path = Pod/VOKKeyPathHelper/VOKKeyPathHelper.m; sourceTree = "<group>"; };
+		CF7FC0370196B29F9A66BC2D86BE2DFD /* libPods-VOKUtilities-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-Tests.a"; path = "libPods-VOKUtilities-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF943555FA063345C8719799BFA5CCAB /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		D28B0744F904025A3F206E815BF09DEE /* NSFileManager-KIFAdditions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSFileManager-KIFAdditions.m"; path = "Additions/NSFileManager-KIFAdditions.m"; sourceTree = "<group>"; };
+		D4035EEAE134DA9E9E58D693E0032ED7 /* VOKUtilities-3288a73d.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-3288a73d.xcconfig"; path = "../VOKUtilities-3288a73d/VOKUtilities-3288a73d.xcconfig"; sourceTree = "<group>"; };
+		D49B7E75B2EC784410F6020249886EB7 /* Pods-VOKUtilities-UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-UITests.debug.xcconfig"; sourceTree = "<group>"; };
+		D532C4FDE263005AE3E45A6159F494F9 /* KIF-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "KIF-dummy.m"; sourceTree = "<group>"; };
+		D5CEAF434166C94DE59DAAE7DD4F5DEA /* VOKUtilities-d8783a65.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-d8783a65.xcconfig"; path = "../VOKUtilities-d8783a65/VOKUtilities-d8783a65.xcconfig"; sourceTree = "<group>"; };
+		D75E027F8AE2A5091E8454AEA4CDCB6B /* Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown"; sourceTree = "<group>"; };
+		D9A37EFF16CB19CD93D1B7F50C97E551 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-VOKUtilities-OSX-Tests-OSX-dummy.m"; sourceTree = "<group>"; };
+		DB3644A7B680161337164688669F6FC0 /* CollectionExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CollectionExtensions.swift; path = Pod/VOKSwiftHelpers/CollectionExtensions.swift; sourceTree = "<group>"; };
+		DB700D0A5D7C153538316439963A2755 /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig"; sourceTree = "<group>"; };
+		DD6D8F55A03EDEC06DEEA50430409CEF /* VOKAlertHelper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VOKAlertHelper.h; path = Pod/VOKAlertHelper/VOKAlertHelper.h; sourceTree = "<group>"; };
+		E0A1C4F11856B891A401832701B2953F /* Pods-VOKUtilities-Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		E1079F5001C1EE90DDC9BCC4B7837489 /* libKIF.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libKIF.a; path = libKIF.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E15A0718E6081AF268BECFC1D9BCBE1F /* Pods-VOKUtilities-OSX-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-OSX-acknowledgements.markdown"; sourceTree = "<group>"; };
+		E1F2A72BE90AF2CB286A2E020E8C865A /* KIFUIViewTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUIViewTestActor.h; path = Classes/KIFUIViewTestActor.h; sourceTree = "<group>"; };
+		E2A86B6D1842B348AD599F343A7618D7 /* CAAnimation+KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CAAnimation+KIFAdditions.h"; path = "Additions/CAAnimation+KIFAdditions.h"; sourceTree = "<group>"; };
+		E51AFD8212C6F6786C56EACF2B507253 /* libVOKUtilities.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libVOKUtilities.a; path = libVOKUtilities.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSNumberFormatter+VOKAL.h"; path = "Pod/NSNumberFormatter+VOKAL/NSNumberFormatter+VOKAL.h"; sourceTree = "<group>"; };
+		E873F20D3342C2BF27D8BAF24630D1CA /* CGGeometry-KIFAdditions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "CGGeometry-KIFAdditions.h"; path = "Additions/CGGeometry-KIFAdditions.h"; sourceTree = "<group>"; };
+		E92104027C0C1133FBCB359D04728612 /* ReuseIdentifiableView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReuseIdentifiableView.swift; path = Pod/VOKSwiftHelpers/ReuseIdentifiableView.swift; sourceTree = "<group>"; };
+		EA6F1D3242408C554EB696E3246C5425 /* KIFTestActor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestActor.h; path = Classes/KIFTestActor.h; sourceTree = "<group>"; };
+		EEDA80244BF2D570DC3C97F1D1074C95 /* KIFUIObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFUIObject.h; path = Classes/KIFUIObject.h; sourceTree = "<group>"; };
+		EFB0B18956FDD720D9DD54564755B2BB /* VOKUtilities-6aa4e1e5.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "VOKUtilities-6aa4e1e5.xcconfig"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5.xcconfig"; sourceTree = "<group>"; };
+		F0D2B0088F319BE6A4F253318B0A18E4 /* UIViewController+VOKKeyboard.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIViewController+VOKKeyboard.h"; path = "Pod/UIViewController+VOKKeyboard/UIViewController+VOKKeyboard.h"; sourceTree = "<group>"; };
+		F3098C8519EE5AF9DDE725384502A6C1 /* KIFUITestActor-ConditionalTests.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "KIFUITestActor-ConditionalTests.m"; path = "Classes/KIFUITestActor-ConditionalTests.m"; sourceTree = "<group>"; };
+		F50A757635B8105A815CB4D4BDA70021 /* Pods-VOKUtilities-tvOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-tvOS-acknowledgements.markdown"; sourceTree = "<group>"; };
+		F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSNumberFormatter+VOKAL.m"; path = "Pod/NSNumberFormatter+VOKAL/NSNumberFormatter+VOKAL.m"; sourceTree = "<group>"; };
+		F844F4295C7FF47A9665AC336786D99E /* Pods-VOKUtilities.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-VOKUtilities.debug.xcconfig"; sourceTree = "<group>"; };
+		F8B2A18DAB1F5200F258DDCC2BD7BCC1 /* VOKUtilities-6aa4e1e5-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "VOKUtilities-6aa4e1e5-prefix.pch"; path = "../VOKUtilities-6aa4e1e5/VOKUtilities-6aa4e1e5-prefix.pch"; sourceTree = "<group>"; };
+		F90C65F0EE08D31A5A527BFC84DE7B23 /* UINibExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UINibExtensions.swift; path = Pod/VOKSwiftHelpers/UINibExtensions.swift; sourceTree = "<group>"; };
+		F9E791F44AE4EBA261E856425070EC4E /* UIView+VOKDebug.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIView+VOKDebug.m"; path = "Pod/UIView+VOKDebug/UIView+VOKDebug.m"; sourceTree = "<group>"; };
+		FA5A993B2BA298207D16B30898FFD72A /* UIView+VOKCircle.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIView+VOKCircle.h"; path = "Pod/UIView+VOKCircle/UIView+VOKCircle.h"; sourceTree = "<group>"; };
+		FAE725F274AABEA1C96774248F696C44 /* libPods-VOKUtilities-watchOS Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = "libPods-VOKUtilities-watchOS Extension.a"; path = "libPods-VOKUtilities-watchOS Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB44C47791414A455E267E8891F8B68B /* KIFTestStepValidation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = KIFTestStepValidation.h; path = Classes/KIFTestStepValidation.h; sourceTree = "<group>"; };
+		FB57E366A6BA18AA1B9EA901665FE31F /* UIColor+VOKAL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIColor+VOKAL.h"; path = "Pod/UIColor+VOKAL/UIColor+VOKAL.h"; sourceTree = "<group>"; };
+		FDE3EACED5087EA9A98117116219DDE7 /* VOKNavigationHelper.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VOKNavigationHelper.m; path = Pod/VOKNavigationHelper/VOKNavigationHelper.m; sourceTree = "<group>"; };
+		FE369C5F2C1AB17D1047FB1AE2F917AB /* Pods-VOKUtilities-UITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-VOKUtilities-UITests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		FF74053941D6124B2FB8972C422C3649 /* VOKUtilities-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VOKUtilities-prefix.pch"; sourceTree = "<group>"; };
+		FF7A4A1C3FAEE1F78712067B580CFEA6 /* KIFAccessibilityEnabler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = KIFAccessibilityEnabler.m; path = Classes/KIFAccessibilityEnabler.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		7EB7687573C25C4A3D6A3317BE7DB9F6 /* Frameworks */ = {
+		270A1EF9610EA8047D0A6EDE920DB68A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1A5DDBFD1A2CB455FD693EB0F49DEFDD /* Frameworks */ = {
+		3BE23949C86917D1F5161C8567A2A009 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D223291F293640B7A3C216FC67088B15 /* Frameworks */ = {
+		42454B7BD5D29905FACA60026AEEA3BF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DB77D48845F8C177DAD98AACE395951B /* Frameworks */ = {
+		448B058306DACEFE16BC39BE0306BCA5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BE760AFCFA49A18172914D68CC12DA2C /* Frameworks */ = {
+		585987FA1407B4C2135286BC140C7827 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		348B2461B5E35D82E3EB9B693A51811B /* Frameworks */ = {
+		6C7FEC29E044F342EB48C89804FFC0A6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D1E0A78515A425ACB73FFF1E5DED5776 /* Frameworks */ = {
+		6CCD7E53AAC839DFA9F4E4FAE796441B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6A617ACE89E98C028849DE07EDE9320A /* Frameworks */ = {
+		79D9411EB5585D447605082B13FBA498 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		012F6BB038ACBFCFA5F3AF5C3431DD93 /* Frameworks */ = {
+		A8197AE3E7886F0B1279EF4C2027E733 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		202FB0DFE2796E987646C7A1B0AFA2A7 /* Frameworks */ = {
+		C4D6AF04DBF4220E78E55ABB1473C786 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8CCF8A2AB3DC98B6D2EF4709D1B8237B /* Frameworks */ = {
+		C7D4CEDCD66751D5AD04C122302083AD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B95CFCDB154F3E721E83996D2954964D /* Frameworks */ = {
+		DC6589C22689019A080EE1848ECEDCB0 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2ABA41855DDC665A6AAD6B07798809AD /* Frameworks */ = {
+		EFE2149A9DC02001EE3800583AE13856 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -529,482 +529,482 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		BD997EE9843ED8D8309848F47E704F39 /* UIView+VOKCircle */ = {
+		04C3660678F225C0E53E2C9D69D9D789 /* UIView+VOKCircle */ = {
 			isa = PBXGroup;
 			children = (
-				20A4CD7B7064BEA07E50E56D65982CDB /* UIView+VOKCircle.h */,
-				D2464B29E90357A61F6E82E61A349E72 /* UIView+VOKCircle.m */,
+				FA5A993B2BA298207D16B30898FFD72A /* UIView+VOKCircle.h */,
+				9FDD3A3C72F3EDD2BAF56BEE0BEEDBB1 /* UIView+VOKCircle.m */,
 			);
 			name = "UIView+VOKCircle";
 			sourceTree = "<group>";
 		};
-		10FAD61D4418EC9DED534354A9CE48F3 /* Pod */ = {
+		0E9006B9CA91271776A811558106DF74 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				CF2AF383D706834200B6F26CC65B3AF3 /* LICENSE */,
-				C51FB359D45002FC335FB99246E9711B /* README.md */,
-				5F7BD544026C63EB5FEC143B6C688B86 /* VOKUtilities.podspec */,
+				B12F9737EFAFE8060BF767C5905FBD69 /* LICENSE */,
+				34223268480812C64A56BFEAE7585775 /* README.md */,
+				1027FFC49594806C3E6A65317C3D1405 /* VOKUtilities.podspec */,
 			);
 			name = Pod;
 			sourceTree = "<group>";
 		};
-		45AE70B02F2C3D20B0BF2B5A093BF92C /* VOKSwiftTestingHelpers */ = {
+		19B895C79CF2AB0D3BF081F7B105F015 /* VOKSwiftTestingHelpers */ = {
 			isa = PBXGroup;
 			children = (
-				B5B1CE26361F736C4418876CDE0D05CD /* TestExtensions.swift */,
+				21DCB575276AC4F1111F8358B9000C0E /* TestExtensions.swift */,
 			);
 			name = VOKSwiftTestingHelpers;
 			sourceTree = "<group>";
 		};
-		0A8E97E16D254C996F1B45FD5DEB3583 /* KIF */ = {
+		1A62038D029009BE5E9843A9FFB63F5F /* KIF */ = {
 			isa = PBXGroup;
 			children = (
-				1603698967CA8356B86B3AC360D3546F /* Core */,
-				A954D19055C3F5D2727572010564A9FF /* Support Files */,
+				FA0A4907D3C18DBE68129AA95B80F53C /* Core */,
+				876903EE05D1A79A163EF0AB3CE0F2F6 /* Support Files */,
 			);
 			name = KIF;
 			path = KIF;
 			sourceTree = "<group>";
 		};
-		A990B7C4D84C0FBB4B1B2B2CD962092F /* NSPredicate+VOKAL */ = {
+		2EA3AD167CCD2C5BF3D5E886A3F41C1E /* NSPredicate+VOKAL */ = {
 			isa = PBXGroup;
 			children = (
-				8B25C5568735013B22EEF35B7C78E6A3 /* NSPredicate+VOKAL.h */,
-				0BAB0D45ADE407A254A81B9585A21B08 /* NSPredicate+VOKAL.m */,
+				6C2A8D76F5467C7BE7C48FE5CD39304E /* NSPredicate+VOKAL.h */,
+				09D1CBD01DD80A12CF1F703E23C73B13 /* NSPredicate+VOKAL.m */,
 			);
 			name = "NSPredicate+VOKAL";
 			sourceTree = "<group>";
 		};
-		F0BEA50F0A3239B839F385C96039AD4E /* Pods-VOKUtilities */ = {
+		3126EA124D2A373088920D6F08030685 /* Pods-VOKUtilities */ = {
 			isa = PBXGroup;
 			children = (
-				4514C29AB56683D41FF3BB3439449241 /* Pods-VOKUtilities-acknowledgements.markdown */,
-				B9B799982F98E2C4B408E86C22032CBC /* Pods-VOKUtilities-acknowledgements.plist */,
-				BFCE8813124E6E256C2262B44D13A271 /* Pods-VOKUtilities-dummy.m */,
-				30EACFB0A4B5C9977D12C365117DC113 /* Pods-VOKUtilities-umbrella.h */,
-				ED67C606E320E7552854220756D4CCD6 /* Pods-VOKUtilities.debug.xcconfig */,
-				E0F996CCB642DC40C564B4B31F0E4938 /* Pods-VOKUtilities.modulemap */,
-				CD9901C057035ECE56BB8051D55F0633 /* Pods-VOKUtilities.release.xcconfig */,
+				83508BC317EB0EDC6E8DA3A2F00E757A /* Pods-VOKUtilities.modulemap */,
+				958BC9F6D4BAAAEC382EEF1AA6C2563A /* Pods-VOKUtilities-acknowledgements.markdown */,
+				1EC901FB7E6B1006E52A354BCE0C78E8 /* Pods-VOKUtilities-acknowledgements.plist */,
+				B41C7A039F78E5386CA01BB57828E11F /* Pods-VOKUtilities-dummy.m */,
+				39722953EC010F554309FCF7B10081C2 /* Pods-VOKUtilities-umbrella.h */,
+				F844F4295C7FF47A9665AC336786D99E /* Pods-VOKUtilities.debug.xcconfig */,
+				5042A0A09414A01B7F161560893592AA /* Pods-VOKUtilities.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities";
 			path = "Target Support Files/Pods-VOKUtilities";
 			sourceTree = "<group>";
 		};
-		27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */ = {
+		393E484A9C78B81210CB8769D46478BA /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				F0BEA50F0A3239B839F385C96039AD4E /* Pods-VOKUtilities */,
-				88911A156B9EABC121AA084BBEAE6F20 /* Pods-VOKUtilities-OSX */,
-				757D513C91924B1631235C1E47845211 /* Pods-VOKUtilities-OSX-Tests-OSX */,
-				4346E1B5A8005553814151948359E009 /* Pods-VOKUtilities-Tests */,
-				3C692562338735D7A3A358CFA86760E3 /* Pods-VOKUtilities-UITests */,
-				008FA9784370CC3F0AEBCAC13B31DBBF /* Pods-VOKUtilities-tvOS */,
-				C74ECCBDB3B3897A563F6FBD7F8B7ED2 /* Pods-VOKUtilities-tvOS-Tests-tvOS */,
-				BC6686E0DD2A5EAE379E98B8E90371B1 /* Pods-VOKUtilities-watchOS Extension */,
+				3126EA124D2A373088920D6F08030685 /* Pods-VOKUtilities */,
+				7A6F22B9297063E968A61846560F22CB /* Pods-VOKUtilities-OSX */,
+				AA387E120A4CE4AC23FA42702D4A9991 /* Pods-VOKUtilities-OSX-Tests-OSX */,
+				3CFCCDC0F0AA982B05C2A63833E4B300 /* Pods-VOKUtilities-Tests */,
+				BC94433A41AC1255ABAFDDE31EFC7423 /* Pods-VOKUtilities-tvOS */,
+				987A8D512B6CFD55FA64FA71F10AAAC9 /* Pods-VOKUtilities-tvOS-Tests-tvOS */,
+				F04C288E520C5BB29EFB002D63E19D0F /* Pods-VOKUtilities-UITests */,
+				503ED63732A06581915885AFA5D40EFD /* Pods-VOKUtilities-watchOS Extension */,
 			);
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		4346E1B5A8005553814151948359E009 /* Pods-VOKUtilities-Tests */ = {
+		3CFCCDC0F0AA982B05C2A63833E4B300 /* Pods-VOKUtilities-Tests */ = {
 			isa = PBXGroup;
 			children = (
-				4F604B77E5AD75277748014CD9F9707D /* Pods-VOKUtilities-Tests-acknowledgements.markdown */,
-				AE1B6395D84041FCBDBA748499FB3960 /* Pods-VOKUtilities-Tests-acknowledgements.plist */,
-				63549E93520A77E3F09A4D1D4B312A15 /* Pods-VOKUtilities-Tests-dummy.m */,
-				34899196A5B74BECD48412B2AC3B604E /* Pods-VOKUtilities-Tests-umbrella.h */,
-				8C1A8A4CBFE4925DA8C6F9B10FE36B53 /* Pods-VOKUtilities-Tests.debug.xcconfig */,
-				4135034912B7B6A288847A7BEC3002ED /* Pods-VOKUtilities-Tests.modulemap */,
-				8DA17411F3736DF097028C4A1D4898EE /* Pods-VOKUtilities-Tests.release.xcconfig */,
+				574C008DD62A18FBCD1B780A1D2F0185 /* Pods-VOKUtilities-Tests.modulemap */,
+				E0A1C4F11856B891A401832701B2953F /* Pods-VOKUtilities-Tests-acknowledgements.markdown */,
+				7379E0BB7B9148E56C92D029622AB3DE /* Pods-VOKUtilities-Tests-acknowledgements.plist */,
+				83485C7C73EBA2B330891D183E40D562 /* Pods-VOKUtilities-Tests-dummy.m */,
+				2C4DFE92C1AB4425A1D4CEEB44BE99B7 /* Pods-VOKUtilities-Tests-umbrella.h */,
+				0517A9AC6133FD1B2804E8E5E6824807 /* Pods-VOKUtilities-Tests.debug.xcconfig */,
+				1A9B9EF968E0FF4C24C53B00C2F1B574 /* Pods-VOKUtilities-Tests.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-Tests";
 			path = "Target Support Files/Pods-VOKUtilities-Tests";
 			sourceTree = "<group>";
 		};
-		FC217A716F76D1C409F4E30CEC56AE89 /* UIView+VOKDebug */ = {
+		4860D77B3CF66E2D9FBC551DCD42D1AD /* UIView+VOKDebug */ = {
 			isa = PBXGroup;
 			children = (
-				4301B56E2795AC2D45FFA210EA2442B7 /* UIView+VOKDebug.h */,
-				F17C226BADEAE2A5853EBCA32CD45AD3 /* UIView+VOKDebug.m */,
+				88BF2E2E241E9005E4094F5268C7A0F4 /* UIView+VOKDebug.h */,
+				F9E791F44AE4EBA261E856425070EC4E /* UIView+VOKDebug.m */,
 			);
 			name = "UIView+VOKDebug";
 			sourceTree = "<group>";
 		};
-		649A8CE29210D8E2D46FB63E03BB42B3 /* NSCalendar+VOKAL */ = {
+		4B9C5C23DFA566DB992C0F319F695B2E /* NSCalendar+VOKAL */ = {
 			isa = PBXGroup;
 			children = (
-				6FD862973C0CBDF7E639D4EA74E7554D /* NSCalendar+VOKAL.h */,
-				64399DFABB8A0545431A78072E932722 /* NSCalendar+VOKAL.m */,
+				8E0BCA6452A60B4C599A02DF017388C4 /* NSCalendar+VOKAL.h */,
+				1994A7651D2A01C97FEFDD36550CBCD9 /* NSCalendar+VOKAL.m */,
 			);
 			name = "NSCalendar+VOKAL";
 			sourceTree = "<group>";
 		};
-		BC6686E0DD2A5EAE379E98B8E90371B1 /* Pods-VOKUtilities-watchOS Extension */ = {
+		503ED63732A06581915885AFA5D40EFD /* Pods-VOKUtilities-watchOS Extension */ = {
 			isa = PBXGroup;
 			children = (
-				90430C18FD9F269165A5864E41E5A094 /* Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown */,
-				435A7641D2D4A7EC508000A860AB876E /* Pods-VOKUtilities-watchOS Extension-acknowledgements.plist */,
-				E7A49122F02B2FCA6A27B688C6333754 /* Pods-VOKUtilities-watchOS Extension-dummy.m */,
-				7BE35F55E952595F1F570BE22C10323A /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */,
-				13B07AA527C974F3D6DF671BAF5F0800 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */,
+				D75E027F8AE2A5091E8454AEA4CDCB6B /* Pods-VOKUtilities-watchOS Extension-acknowledgements.markdown */,
+				BA841049A5BC321DEE9BDFC72F97BB67 /* Pods-VOKUtilities-watchOS Extension-acknowledgements.plist */,
+				B3F93316D7B8B6B844EF451E989B6704 /* Pods-VOKUtilities-watchOS Extension-dummy.m */,
+				BB61F8D7346713C87C910D82A030E7A2 /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */,
+				58B99DC0D6F954E7E2947E02D026A960 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-watchOS Extension";
 			path = "Target Support Files/Pods-VOKUtilities-watchOS Extension";
 			sourceTree = "<group>";
 		};
-		1432AA59D8B53139E350543A9C80D7F8 /* Pods */ = {
+		5E65F315E23BDC3400FD383481CC67F7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				0A8E97E16D254C996F1B45FD5DEB3583 /* KIF */,
+				1A62038D029009BE5E9843A9FFB63F5F /* KIF */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */ = {
+		5EB4D956D64EB040A5C21749E339DC18 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				9F9D430B6941C0F4D78D8E7C77199599 /* libKIF.a */,
-				1EA2E4CE4A681ADC33B94043FB65AEE7 /* libPods-VOKUtilities-OSX-Tests-OSX.a */,
-				0EF5C3FEB1E5D96EC3D465DC08AF03E0 /* libPods-VOKUtilities-OSX.a */,
-				BC8DA6D0DF596D1B39DDDFB944ACA263 /* libPods-VOKUtilities-Tests.a */,
-				9D2CBBE22941DDAB01BE14CA7FB26D60 /* libPods-VOKUtilities-UITests.a */,
-				D0DEF7D991C888FA2532FC5389298272 /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */,
-				485C9F17FB14C43CB2B71C519FEF526A /* libPods-VOKUtilities-tvOS.a */,
-				0BA9E8381AD94FC457CA0FE358F99BAC /* libPods-VOKUtilities-watchOS Extension.a */,
-				2027DDAB90D2F6D9748A850FF1468A8B /* libPods-VOKUtilities.a */,
-				1DA0DBDAC8F6E17E4219EC784294DE16 /* libVOKUtilities-3288a73d.a */,
-				5AB028AA13C5B05486B99715DE144FA1 /* libVOKUtilities-6aa4e1e5.a */,
-				BC1831D9749CA200885645CFCF267C6C /* libVOKUtilities-d8783a65.a */,
-				F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */,
+				E1079F5001C1EE90DDC9BCC4B7837489 /* libKIF.a */,
+				AC85B484287AB5C191B492814CE5B59A /* libPods-VOKUtilities.a */,
+				0323B2E7B3935FD08D198AD047C5EE5F /* libPods-VOKUtilities-OSX.a */,
+				936B509B358510D3EADBF473EAA85AC2 /* libPods-VOKUtilities-OSX-Tests-OSX.a */,
+				CF7FC0370196B29F9A66BC2D86BE2DFD /* libPods-VOKUtilities-Tests.a */,
+				AB89795847149BFD57F40652E55F4666 /* libPods-VOKUtilities-tvOS.a */,
+				29C8F167BEDFA04DF429BC1FA428BF2B /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */,
+				8800680AA42C25DA643210E051BD64C2 /* libPods-VOKUtilities-UITests.a */,
+				FAE725F274AABEA1C96774248F696C44 /* libPods-VOKUtilities-watchOS Extension.a */,
+				E51AFD8212C6F6786C56EACF2B507253 /* libVOKUtilities.a */,
+				757DC2EBFACA2FDDD756AEAC3298FD09 /* libVOKUtilities-3288a73d.a */,
+				308B8869DF208C08C36B1785FDEE019F /* libVOKUtilities-6aa4e1e5.a */,
+				A1F46A1672C999E6E7F27CC368D40F9F /* libVOKUtilities-d8783a65.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		6F09599F77DA1730C3546425B72BA0F4 /* UIViewController+VOKKeyboard */ = {
+		6D48F6606A467594C65C644E523A41E8 /* UIViewController+VOKKeyboard */ = {
 			isa = PBXGroup;
 			children = (
-				7FD426CC804F6333DAD835F63C7A1FB4 /* UIViewController+VOKKeyboard.h */,
-				97810B020D58E5EE39D7588552BF2AE6 /* UIViewController+VOKKeyboard.m */,
+				F0D2B0088F319BE6A4F253318B0A18E4 /* UIViewController+VOKKeyboard.h */,
+				B18BB318989ED0FC237001B0C79B3385 /* UIViewController+VOKKeyboard.m */,
 			);
 			name = "UIViewController+VOKKeyboard";
 			sourceTree = "<group>";
 		};
-		E9F0214B8235BEE2230BFF54620CAB3A /* VOKUtilities */ = {
+		767F8A72DCD6A5736CBD60FA07413308 /* VOKUtilities */ = {
 			isa = PBXGroup;
 			children = (
-				649A8CE29210D8E2D46FB63E03BB42B3 /* NSCalendar+VOKAL */,
-				8A2BE84B066B99CC49937D0F1E1EEE26 /* NSNumberFormatter+VOKAL */,
-				A990B7C4D84C0FBB4B1B2B2CD962092F /* NSPredicate+VOKAL */,
-				AE306033D6378ECA312FB97478394F03 /* NSString+VOKValidation */,
-				10FAD61D4418EC9DED534354A9CE48F3 /* Pod */,
-				0FDA69FE9A58E373F0A817B08CC15D98 /* Support Files */,
-				C2FB1759F92DA3F9D7501D141D50D695 /* UIColor+VOKAL */,
-				BD997EE9843ED8D8309848F47E704F39 /* UIView+VOKCircle */,
-				FC217A716F76D1C409F4E30CEC56AE89 /* UIView+VOKDebug */,
-				6F09599F77DA1730C3546425B72BA0F4 /* UIViewController+VOKKeyboard */,
-				6322530AAF1981CE75B77FFE5A25B6F2 /* VOKAlertHelper */,
-				CBCE1A28317CF31360E473BFBB734BE5 /* VOKEmailHelper */,
-				5D63326D99BF17F8716E8C5428AFAAF1 /* VOKIBHelpers */,
-				2125B305B79C03CD5B21F89705F9ED27 /* VOKKeyPathHelper */,
-				5BA378C6EA28297A426C982754A11F4C /* VOKNavigationHelper */,
-				F76D46B5CAAF4AB79BA523C0082F9B60 /* VOKSwiftHelpers */,
-				45AE70B02F2C3D20B0BF2B5A093BF92C /* VOKSwiftTestingHelpers */,
+				4B9C5C23DFA566DB992C0F319F695B2E /* NSCalendar+VOKAL */,
+				C544CD3B39BF93086E9FF24D24EB7107 /* NSNumberFormatter+VOKAL */,
+				2EA3AD167CCD2C5BF3D5E886A3F41C1E /* NSPredicate+VOKAL */,
+				E15B4EC8CBDCB4624E880AD42B69CE5D /* NSString+VOKValidation */,
+				0E9006B9CA91271776A811558106DF74 /* Pod */,
+				8879B5B32B021940F3BA266C44187A87 /* Support Files */,
+				F17134F555EF09857E4A0EE5EA4ED215 /* UIColor+VOKAL */,
+				04C3660678F225C0E53E2C9D69D9D789 /* UIView+VOKCircle */,
+				4860D77B3CF66E2D9FBC551DCD42D1AD /* UIView+VOKDebug */,
+				6D48F6606A467594C65C644E523A41E8 /* UIViewController+VOKKeyboard */,
+				D4CDC4BA47BD2604A79AB3B4BD35E713 /* VOKAlertHelper */,
+				7D671E515DF17B560E6EF75C4A2A64B8 /* VOKEmailHelper */,
+				7CB8BFCA879FF770DB4BC0C86022B5FB /* VOKIBHelpers */,
+				E4E03CF9884B16526FF570A8C77FBABF /* VOKKeyPathHelper */,
+				F2364B26C534293B077CB203E8749AE3 /* VOKNavigationHelper */,
+				AB175F8253EBB8103D242967A4DE3369 /* VOKSwiftHelpers */,
+				19B895C79CF2AB0D3BF081F7B105F015 /* VOKSwiftTestingHelpers */,
 			);
 			name = VOKUtilities;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		88911A156B9EABC121AA084BBEAE6F20 /* Pods-VOKUtilities-OSX */ = {
+		7A6F22B9297063E968A61846560F22CB /* Pods-VOKUtilities-OSX */ = {
 			isa = PBXGroup;
 			children = (
-				9A7796F972460D034535C4D684AE9906 /* Pods-VOKUtilities-OSX-acknowledgements.markdown */,
-				28DFE8D097100F6E801FA545A2D271CC /* Pods-VOKUtilities-OSX-acknowledgements.plist */,
-				6FBC33B60F1AA6C846FB94D7A54A427F /* Pods-VOKUtilities-OSX-dummy.m */,
-				CD428AC25745BAAB289F14779E117C98 /* Pods-VOKUtilities-OSX.debug.xcconfig */,
-				E702990E1D564EED03C1C1F7FC2F4926 /* Pods-VOKUtilities-OSX.release.xcconfig */,
+				E15A0718E6081AF268BECFC1D9BCBE1F /* Pods-VOKUtilities-OSX-acknowledgements.markdown */,
+				9A70988694FC02FC177D68D52C526C0D /* Pods-VOKUtilities-OSX-acknowledgements.plist */,
+				AAF268E9E4A06FAD59C701B09281816D /* Pods-VOKUtilities-OSX-dummy.m */,
+				122F88ABE31C9661F41BF8C723518A9B /* Pods-VOKUtilities-OSX.debug.xcconfig */,
+				1983AB640BD3B786ED8CEF6ABEE7055F /* Pods-VOKUtilities-OSX.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-OSX";
 			path = "Target Support Files/Pods-VOKUtilities-OSX";
 			sourceTree = "<group>";
 		};
-		5D63326D99BF17F8716E8C5428AFAAF1 /* VOKIBHelpers */ = {
+		7CB8BFCA879FF770DB4BC0C86022B5FB /* VOKIBHelpers */ = {
 			isa = PBXGroup;
 			children = (
-				4946387BF9A6FF2D57B19DD94B3EC7B6 /* VOKIBHelpers.h */,
+				B73F039820602899FC064D51F35D6811 /* VOKIBHelpers.h */,
 			);
 			name = VOKIBHelpers;
 			sourceTree = "<group>";
 		};
-		CBCE1A28317CF31360E473BFBB734BE5 /* VOKEmailHelper */ = {
+		7D671E515DF17B560E6EF75C4A2A64B8 /* VOKEmailHelper */ = {
 			isa = PBXGroup;
 			children = (
-				539B968AED0250154DD058D2A030CF2A /* VOKEmailHelper.h */,
-				897C087446E9AF6C97482464C4B5008E /* VOKEmailHelper.m */,
+				2726E5B730EC22550A4079BA18304260 /* VOKEmailHelper.h */,
+				412CE532FEF0F2981DD2B75FF5C75616 /* VOKEmailHelper.m */,
 			);
 			name = VOKEmailHelper;
 			sourceTree = "<group>";
 		};
-		A954D19055C3F5D2727572010564A9FF /* Support Files */ = {
+		876903EE05D1A79A163EF0AB3CE0F2F6 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				A35778B6C24123BBCE0BDF8374FF1785 /* KIF-dummy.m */,
-				D87BDC90E71C64BC95F0DF1CC76A4D37 /* KIF-prefix.pch */,
-				EF15B543402F7F49A37C463991728D76 /* KIF.xcconfig */,
+				81A17D35F50E350E5ADA4F8213AC0ADB /* KIF.xcconfig */,
+				D532C4FDE263005AE3E45A6159F494F9 /* KIF-dummy.m */,
+				917BAEA5E6FE1ECA0EC4E03E35BEE1DA /* KIF-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/KIF";
 			sourceTree = "<group>";
 		};
-		0FDA69FE9A58E373F0A817B08CC15D98 /* Support Files */ = {
+		8879B5B32B021940F3BA266C44187A87 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				379CF77118C12B75295BD85B4CA0DFBD /* VOKUtilities-3288a73d-dummy.m */,
-				ADAD5CD77D5A9BA700D173E34D2D1EE8 /* VOKUtilities-3288a73d-prefix.pch */,
-				D99E80F18BCD42A08B320FC4192E2FFA /* VOKUtilities-3288a73d.xcconfig */,
-				D8B0FCC063D0CD74D625A87B64684D42 /* VOKUtilities-6aa4e1e5-dummy.m */,
-				4C1F449780836CAF00C32D235EFA8B91 /* VOKUtilities-6aa4e1e5-prefix.pch */,
-				13E8F743E7B20474C0FC3B5DAB277F35 /* VOKUtilities-6aa4e1e5.xcconfig */,
-				33E0CEF423F7E0E1E13F20176AB3D1FA /* VOKUtilities-d8783a65-dummy.m */,
-				C25FE3AA2706BFE0EAD221EF5AB8D41E /* VOKUtilities-d8783a65-prefix.pch */,
-				F8BFCFF33D82958419B37BCA846C71B1 /* VOKUtilities-d8783a65.xcconfig */,
-				503B1DA7882CF4FC214BA50FA5C81381 /* VOKUtilities-dummy.m */,
-				4F2DD0BCC66E54C89AB77D98895D8DE8 /* VOKUtilities-prefix.pch */,
-				B3144E20058BB126BDACD9FA48DA592B /* VOKUtilities-umbrella.h */,
-				3FF9C68007F56397C29669B0F2391B52 /* VOKUtilities.modulemap */,
-				F66D42ACC4DFF844005E41B9E0CBC148 /* VOKUtilities.xcconfig */,
+				8450F7A572E5020573BF40FAF93D3143 /* VOKUtilities.modulemap */,
+				B29767A5C3680270E1CFAEC28527606C /* VOKUtilities.xcconfig */,
+				D4035EEAE134DA9E9E58D693E0032ED7 /* VOKUtilities-3288a73d.xcconfig */,
+				5A5184C6661DCE28CE8100F2713E64D7 /* VOKUtilities-3288a73d-dummy.m */,
+				395975096FCAF8C7B95024372C39BA80 /* VOKUtilities-3288a73d-prefix.pch */,
+				EFB0B18956FDD720D9DD54564755B2BB /* VOKUtilities-6aa4e1e5.xcconfig */,
+				A8EB4AA5B1E3A63DDCFB03D425760363 /* VOKUtilities-6aa4e1e5-dummy.m */,
+				F8B2A18DAB1F5200F258DDCC2BD7BCC1 /* VOKUtilities-6aa4e1e5-prefix.pch */,
+				D5CEAF434166C94DE59DAAE7DD4F5DEA /* VOKUtilities-d8783a65.xcconfig */,
+				8B8430C1E080ADCD9C8221E796C16536 /* VOKUtilities-d8783a65-dummy.m */,
+				46D82AA661E046BBDC5AFC9FAD973AEC /* VOKUtilities-d8783a65-prefix.pch */,
+				5F9CE4800E3E4DE254FFC8ACA1DFBF4A /* VOKUtilities-dummy.m */,
+				FF74053941D6124B2FB8972C422C3649 /* VOKUtilities-prefix.pch */,
+				2D6A2DF9A51B33B59B6B04246C8225ED /* VOKUtilities-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/VOKUtilities";
 			sourceTree = "<group>";
 		};
-		C74ECCBDB3B3897A563F6FBD7F8B7ED2 /* Pods-VOKUtilities-tvOS-Tests-tvOS */ = {
+		987A8D512B6CFD55FA64FA71F10AAAC9 /* Pods-VOKUtilities-tvOS-Tests-tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				4F8D05296274DEBA7632AEDF222F5004 /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown */,
-				D4D0E72F17625EF3AD5416C89D4C85DF /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist */,
-				1BF36B086797549DA57E4D1ED31D7E9A /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */,
-				5B6F3052431F469A793BE88E4C436B0E /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */,
-				84DC51BF57AF57827E9A253D63707FF0 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */,
+				1BADF65E39AFB8DA21FE55349C987D8D /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.markdown */,
+				CF943555FA063345C8719799BFA5CCAB /* Pods-VOKUtilities-tvOS-Tests-tvOS-acknowledgements.plist */,
+				3ABA7F3D50FFE083C48A97A824A19FD2 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m */,
+				535DEC30191070958A7B52EFA68E623D /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */,
+				16ACF05D99F205680763E44C25073327 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-tvOS-Tests-tvOS";
 			path = "Target Support Files/Pods-VOKUtilities-tvOS-Tests-tvOS";
 			sourceTree = "<group>";
 		};
-		757D513C91924B1631235C1E47845211 /* Pods-VOKUtilities-OSX-Tests-OSX */ = {
+		AA387E120A4CE4AC23FA42702D4A9991 /* Pods-VOKUtilities-OSX-Tests-OSX */ = {
 			isa = PBXGroup;
 			children = (
-				2C4570663FACBCC2F9F9254A30F2B6E2 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown */,
-				D4787344129E379F792F1B4F76E67EEB /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist */,
-				93C1F60F551AAE4A5596F0509FD12080 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */,
-				76A781B779B12B2F733B1116E68F29EB /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */,
-				579E47755F2232EABA83A095AC14CD4F /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */,
+				0740D885F6BF96D914FE155B29BD9254 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.markdown */,
+				C4B495B81B1987A183CB1523CE6A95C8 /* Pods-VOKUtilities-OSX-Tests-OSX-acknowledgements.plist */,
+				D9A37EFF16CB19CD93D1B7F50C97E551 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m */,
+				DB700D0A5D7C153538316439963A2755 /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */,
+				BEFA062B53BA6DD40FCEC89CBCC19AA3 /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-OSX-Tests-OSX";
 			path = "Target Support Files/Pods-VOKUtilities-OSX-Tests-OSX";
 			sourceTree = "<group>";
 		};
-		F76D46B5CAAF4AB79BA523C0082F9B60 /* VOKSwiftHelpers */ = {
+		AB175F8253EBB8103D242967A4DE3369 /* VOKSwiftHelpers */ = {
 			isa = PBXGroup;
 			children = (
-				194EF860C6A8E7FF250F4610C226C53C /* CollectionExtensions.swift */,
-				DDB05E62BE4B902B8167754B5EFAD9AD /* IntExtensions.swift */,
-				B079723D272DFBD587B9C07E0C155CFD /* ReuseIdentifiableView.swift */,
-				57A61A555D420DAFD08F7B9507736FDB /* StringExtensions.swift */,
-				BB0DD57D7B392CC2A2FB7185EBB16DC0 /* UIApplicationExtensions.swift */,
-				178F01BDE8B0AA721DC702109424DE4D /* UICollectionViewExtensions.swift */,
-				96765F99C5599CDB310AD2629DB4AD8F /* UINibExtensions.swift */,
-				597EC2B7AF0298EF0982727A230E0C41 /* UIPageControlExtensions.swift */,
-				034CF336EFC2AF1B9C40C2D55BC32A6E /* UIStackViewExtensions.swift */,
-				BF5CC52BD45D5DC5AC5B6C7E8A20FA29 /* UITableViewExtensions.swift */,
-				3CBAD6C3929307C1FF7FF66F93341BFB /* UIViewControllerExtensions.swift */,
-				4692CBC3D274691C896935932772AC38 /* UIViewExtensions.swift */,
+				DB3644A7B680161337164688669F6FC0 /* CollectionExtensions.swift */,
+				39FB67AF286433AB5C9B10556E59AD5F /* IntExtensions.swift */,
+				E92104027C0C1133FBCB359D04728612 /* ReuseIdentifiableView.swift */,
+				1FCDB84A999C6239642A0C86AF5187ED /* StringExtensions.swift */,
+				3BC07C3EE3A42393D975E7ED89D62FA5 /* UIApplicationExtensions.swift */,
+				9A82912D473727D116393FA848F39670 /* UICollectionViewExtensions.swift */,
+				F90C65F0EE08D31A5A527BFC84DE7B23 /* UINibExtensions.swift */,
+				9E4377273F78EE37208EED36CDB04551 /* UIPageControlExtensions.swift */,
+				C70B7311518312C7CE85782D260AD7AC /* UIStackViewExtensions.swift */,
+				9AAE5091D65A00AC3B3055B7063E8321 /* UITableViewExtensions.swift */,
+				9AFC276BAF15F4593D1193BAAB407F2E /* UIViewControllerExtensions.swift */,
+				459206F7183A0580D0A974F5D993DBFF /* UIViewExtensions.swift */,
 			);
 			name = VOKSwiftHelpers;
 			sourceTree = "<group>";
 		};
-		008FA9784370CC3F0AEBCAC13B31DBBF /* Pods-VOKUtilities-tvOS */ = {
+		BC94433A41AC1255ABAFDDE31EFC7423 /* Pods-VOKUtilities-tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				44129A44AD5306FC1A42BF9A24A253EB /* Pods-VOKUtilities-tvOS-acknowledgements.markdown */,
-				83A42E026B8EBFE55A19EEF37B0BE90B /* Pods-VOKUtilities-tvOS-acknowledgements.plist */,
-				B600193CBD1685C27B42E5F11EC055D6 /* Pods-VOKUtilities-tvOS-dummy.m */,
-				64DD439F1A6E7228733309C3C4B2F0F1 /* Pods-VOKUtilities-tvOS.debug.xcconfig */,
-				F0986C9E216ADEE673E9422FE401F0E1 /* Pods-VOKUtilities-tvOS.release.xcconfig */,
+				F50A757635B8105A815CB4D4BDA70021 /* Pods-VOKUtilities-tvOS-acknowledgements.markdown */,
+				1370D45A652E01B5A12123D70C2F6109 /* Pods-VOKUtilities-tvOS-acknowledgements.plist */,
+				114C99483DA0435B8B321E3BB40EFC77 /* Pods-VOKUtilities-tvOS-dummy.m */,
+				6DC5BCE78DF9B83DFA827C00999804D2 /* Pods-VOKUtilities-tvOS.debug.xcconfig */,
+				2DF28D9FB0A77A7D6810DA3DA867835F /* Pods-VOKUtilities-tvOS.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-tvOS";
 			path = "Target Support Files/Pods-VOKUtilities-tvOS";
 			sourceTree = "<group>";
 		};
-		8A2BE84B066B99CC49937D0F1E1EEE26 /* NSNumberFormatter+VOKAL */ = {
+		C544CD3B39BF93086E9FF24D24EB7107 /* NSNumberFormatter+VOKAL */ = {
 			isa = PBXGroup;
 			children = (
-				5054385FED12C025C05F4486CBFCC52D /* NSNumberFormatter+VOKAL.h */,
-				DCF1DC8935C38995A3D843EF0B9A5AE0 /* NSNumberFormatter+VOKAL.m */,
+				E74A915B50388DA17F202791D0480FE1 /* NSNumberFormatter+VOKAL.h */,
+				F7DCEC030BFB51493056BF3A1F417851 /* NSNumberFormatter+VOKAL.m */,
 			);
 			name = "NSNumberFormatter+VOKAL";
 			sourceTree = "<group>";
 		};
-		5DECD2D2DDBCF1DF25E1166EAF85634C = {
+		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
 			children = (
-				6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */,
-				DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */,
-				A38FF61C71733211E6DDB19385503404 /* Podfile */,
-				1432AA59D8B53139E350543A9C80D7F8 /* Pods */,
-				F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */,
-				27E772C472EE5BD87EA005C1E920FEC6 /* Targets Support Files */,
+				9D940727FF8FB9C785EB98E56350EF41 /* Podfile */,
+				F9462C07D08D22EB7E5BAAF3A7DEF929 /* Development Pods */,
+				D89477F20FB1DE18A04690586D7808C4 /* Frameworks */,
+				5E65F315E23BDC3400FD383481CC67F7 /* Pods */,
+				5EB4D956D64EB040A5C21749E339DC18 /* Products */,
+				393E484A9C78B81210CB8769D46478BA /* Targets Support Files */,
 			);
 			sourceTree = "<group>";
 		};
-		6322530AAF1981CE75B77FFE5A25B6F2 /* VOKAlertHelper */ = {
+		D4CDC4BA47BD2604A79AB3B4BD35E713 /* VOKAlertHelper */ = {
 			isa = PBXGroup;
 			children = (
-				65DC44433D5FFC84888264D2C5C493A7 /* VOKAlertAction.h */,
-				CE75EB0B319CCD614A56A3023437873E /* VOKAlertAction.m */,
-				377FB8124253238FE62A2FCD52DF4A28 /* VOKAlertHelper.h */,
-				4350F6DBBC66436788316D6FDB1A3DC1 /* VOKAlertHelper.m */,
+				3D3CC3F3D88EB64F8E42431417BF85B0 /* VOKAlertAction.h */,
+				796057F69E112F4A6754BDB9DDD99FF0 /* VOKAlertAction.m */,
+				DD6D8F55A03EDEC06DEEA50430409CEF /* VOKAlertHelper.h */,
+				74FE8D0865073F2272438CF9F0462D95 /* VOKAlertHelper.m */,
 			);
 			name = VOKAlertHelper;
 			sourceTree = "<group>";
 		};
-		DC48BCE815EC154A59BCA69936CF7135 /* Frameworks */ = {
+		D89477F20FB1DE18A04690586D7808C4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		AE306033D6378ECA312FB97478394F03 /* NSString+VOKValidation */ = {
+		E15B4EC8CBDCB4624E880AD42B69CE5D /* NSString+VOKValidation */ = {
 			isa = PBXGroup;
 			children = (
-				FEA90AF3B0CB1E117DB50B296578CC80 /* NSString+VOKValidation.h */,
-				5F7C42677F7C9A79C49CF6A4D7BD0AE7 /* NSString+VOKValidation.m */,
+				35768ABFC338A41C6DCA41ECACE7AAC9 /* NSString+VOKValidation.h */,
+				B4B9F6ACADF6CE91DFFC66B1B40BCF3B /* NSString+VOKValidation.m */,
 			);
 			name = "NSString+VOKValidation";
 			sourceTree = "<group>";
 		};
-		2125B305B79C03CD5B21F89705F9ED27 /* VOKKeyPathHelper */ = {
+		E4E03CF9884B16526FF570A8C77FBABF /* VOKKeyPathHelper */ = {
 			isa = PBXGroup;
 			children = (
-				2D822A56C377A6B2127684888CA2DE6D /* VOKKeyPathHelper.h */,
-				875B2180B467D07AEB9AC13FAEF70DDE /* VOKKeyPathHelper.m */,
+				79BE43E32B780C62D50677C704D0B45E /* VOKKeyPathHelper.h */,
+				CC5B1902369336186C94589D36D0F8D6 /* VOKKeyPathHelper.m */,
 			);
 			name = VOKKeyPathHelper;
 			sourceTree = "<group>";
 		};
-		3C692562338735D7A3A358CFA86760E3 /* Pods-VOKUtilities-UITests */ = {
+		F04C288E520C5BB29EFB002D63E19D0F /* Pods-VOKUtilities-UITests */ = {
 			isa = PBXGroup;
 			children = (
-				42A88C6B5E103F45264640EA6C6FCA1E /* Pods-VOKUtilities-UITests-acknowledgements.markdown */,
-				76D7AF041DBC51EC3B274785061F54D4 /* Pods-VOKUtilities-UITests-acknowledgements.plist */,
-				F3A5ACE5802CD9BF2BBEB9B0E4AC5A14 /* Pods-VOKUtilities-UITests-dummy.m */,
-				DCDB3273BA404F6066880F97898DC7A7 /* Pods-VOKUtilities-UITests-umbrella.h */,
-				72F5DB8C343D2FD7F7CEFD948C7E3163 /* Pods-VOKUtilities-UITests.debug.xcconfig */,
-				87B124C56F34AB0239E22F12FC1E1A81 /* Pods-VOKUtilities-UITests.modulemap */,
-				FAE18B5CBCA58BE2C1F5F17C91E25481 /* Pods-VOKUtilities-UITests.release.xcconfig */,
+				18951E6700E59990FC623EA7184983D9 /* Pods-VOKUtilities-UITests.modulemap */,
+				FE369C5F2C1AB17D1047FB1AE2F917AB /* Pods-VOKUtilities-UITests-acknowledgements.markdown */,
+				0CB62E3C55E68B91C2F902844B260D2E /* Pods-VOKUtilities-UITests-acknowledgements.plist */,
+				500CF15B061A6A075A8FC952674FAFF7 /* Pods-VOKUtilities-UITests-dummy.m */,
+				A03C585586FB4FA6F08DC89532F3B631 /* Pods-VOKUtilities-UITests-umbrella.h */,
+				D49B7E75B2EC784410F6020249886EB7 /* Pods-VOKUtilities-UITests.debug.xcconfig */,
+				477C6FDE8319E8DE89215F370869DC4E /* Pods-VOKUtilities-UITests.release.xcconfig */,
 			);
 			name = "Pods-VOKUtilities-UITests";
 			path = "Target Support Files/Pods-VOKUtilities-UITests";
 			sourceTree = "<group>";
 		};
-		C2FB1759F92DA3F9D7501D141D50D695 /* UIColor+VOKAL */ = {
+		F17134F555EF09857E4A0EE5EA4ED215 /* UIColor+VOKAL */ = {
 			isa = PBXGroup;
 			children = (
-				33CEE1101EE293C815A79795491E011C /* UIColor+VOKAL.h */,
-				2380DEE445F849E6502C0B33E5D53DB2 /* UIColor+VOKAL.m */,
+				FB57E366A6BA18AA1B9EA901665FE31F /* UIColor+VOKAL.h */,
+				AE27AF49804C51AA236906DA7BCE2811 /* UIColor+VOKAL.m */,
 			);
 			name = "UIColor+VOKAL";
 			sourceTree = "<group>";
 		};
-		5BA378C6EA28297A426C982754A11F4C /* VOKNavigationHelper */ = {
+		F2364B26C534293B077CB203E8749AE3 /* VOKNavigationHelper */ = {
 			isa = PBXGroup;
 			children = (
-				BF3473BEBB7814DE9D6C3D8DD0F0B325 /* VOKNavigationHelper.h */,
-				363780D517F2382F3736DF8DBED7B2FA /* VOKNavigationHelper.m */,
+				C65C1DB7F125B6F5B0D441534484989A /* VOKNavigationHelper.h */,
+				FDE3EACED5087EA9A98117116219DDE7 /* VOKNavigationHelper.m */,
 			);
 			name = VOKNavigationHelper;
 			sourceTree = "<group>";
 		};
-		6D1EB8A38E8CBA4A4B0D3C897A545D0A /* Development Pods */ = {
+		F9462C07D08D22EB7E5BAAF3A7DEF929 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E9F0214B8235BEE2230BFF54620CAB3A /* VOKUtilities */,
+				767F8A72DCD6A5736CBD60FA07413308 /* VOKUtilities */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		1603698967CA8356B86B3AC360D3546F /* Core */ = {
+		FA0A4907D3C18DBE68129AA95B80F53C /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				1DA5CD3CB63E36161B8B3F7D2AE992D4 /* CAAnimation+KIFAdditions.h */,
-				9E9D4FF885B6420C53C798213CB6F667 /* CAAnimation+KIFAdditions.m */,
-				256DEF5EE755F113C0B6270B66D49D70 /* CALayer-KIFAdditions.h */,
-				EA19F51A2FE1C42DA25FEA6626DEE3A8 /* CALayer-KIFAdditions.m */,
-				D0A1AAADA3718C26BEDA11972236982D /* CGGeometry-KIFAdditions.h */,
-				1C54769710256DCE42AEA47FC1796100 /* CGGeometry-KIFAdditions.m */,
-				CBAEF907BAE6FCDB4794D2E4E87A90F9 /* IOHIDEvent+KIF.h */,
-				CB93C13BA7F134BFD2C7BB64ACF8341E /* IOHIDEvent+KIF.m */,
-				6ECC6C36A1FE4487BD6BB7DB0118ED92 /* KIF.h */,
-				7B8A5E046B2AFF2DC30BD3766C24CF67 /* KIFAccessibilityEnabler.h */,
-				BD670D013D07DB00D4B63F7892B966E1 /* KIFAccessibilityEnabler.m */,
-				2EF1B36C66BB0936103C7E0186726C96 /* KIFSystemTestActor.h */,
-				677EFD77558EFB013D0637E1C5CBB78B /* KIFSystemTestActor.m */,
-				0B527B31C8C2CD122453B890EA16CC10 /* KIFTestActor.h */,
-				517ED2C363C638C9C87EA07B44DAD95E /* KIFTestActor.m */,
-				86EE106EFD91F4055298ECEFA75EC708 /* KIFTestActor_Private.h */,
-				EDFF3811160CAB00B75A3527AC3FBA84 /* KIFTestCase.h */,
-				75002ED02DCCD44E7C3716FF4996F7F9 /* KIFTestCase.m */,
-				985A8D1AA3BDB7813306E8821C78CF89 /* KIFTestStepValidation.h */,
-				A4AA1C147142E6BC25ED4406512B202C /* KIFTestStepValidation.m */,
-				7807FF379AFCC58BC2BAD44ACD52B0A5 /* KIFTextInputTraitsOverrides.h */,
-				581EC5DBC1CC58700497B5E95EC97749 /* KIFTextInputTraitsOverrides.m */,
-				1169221C7B97C2DAFB2BBCFFA16DF5BC /* KIFTypist.h */,
-				81431A9D8F3C092AC4EF8AE853DD2CD2 /* KIFTypist.m */,
-				B16D78479F7BC8735D9E8AFEF12E8885 /* KIFUIObject.h */,
-				FDDAAE622B38279FE2EB519A3E6B7325 /* KIFUIObject.m */,
-				6A456C4CD44B27EC83A46E6592B636F6 /* KIFUITestActor-ConditionalTests.h */,
-				E6B821C956E09EED40CE51D0DC172B92 /* KIFUITestActor-ConditionalTests.m */,
-				2B73383BCC98B3B2BE21180C9BA86AFC /* KIFUITestActor.h */,
-				4A2FC0BA9CEF0B9CFFA92673B3508CE6 /* KIFUITestActor.m */,
-				474AB8842D8050D22E17343C6A909D06 /* KIFUITestActor_Private.h */,
-				5F8B15F21426F6555FDFEAA4A962DC0D /* KIFUIViewTestActor.h */,
-				31C7A9C567311B2D0F46989E4BCCC2DD /* KIFUIViewTestActor.m */,
-				42CA77640067E7DA9A0BB1FAC1D3D2B2 /* LoadableCategory.h */,
-				227D2CB3CE006DBA8987F570E24E27BB /* NSBundle-KIFAdditions.h */,
-				ED7DB0C3584C9A1D28AAC215655FE8F7 /* NSBundle-KIFAdditions.m */,
-				89D2DAC405F59379DD0C063CAD8A3DC9 /* NSError-KIFAdditions.h */,
-				D87E653802EDDAE89AB6C5AC4519FE0C /* NSError-KIFAdditions.m */,
-				08606E64F97E62AB69E00094E99B9D9D /* NSException-KIFAdditions.h */,
-				816653EBF4A7423D28A018E4CECB3CAB /* NSException-KIFAdditions.m */,
-				9BDD479E47692C1EDCD90703EFACE6AD /* NSFileManager-KIFAdditions.h */,
-				BCDDFB59ECA27DFF764451EBDF5437B6 /* NSFileManager-KIFAdditions.m */,
-				961B37A8618299428554DA07AEAFF7E0 /* NSPredicate+KIFAdditions.h */,
-				32B3356984D0A9EF907D5CE19E5E5C63 /* NSPredicate+KIFAdditions.m */,
-				BC18DF79704D5B3DDC5E4C820C38A156 /* NSString+KIFAdditions.h */,
-				C8FFFCEF9350F68C38CC0018FF010E3A /* NSString+KIFAdditions.m */,
-				D92528D1BED762A6EB1FE90D8EB82465 /* UIAccessibilityElement-KIFAdditions.h */,
-				233A764FCA600EF78B3D8B3AA79EED83 /* UIAccessibilityElement-KIFAdditions.m */,
-				1A4BE4C2273429BE0E4BCA0FF473F03B /* UIApplication-KIFAdditions.h */,
-				B5AD899775892E8E32CA7347043D7435 /* UIApplication-KIFAdditions.m */,
-				AA3F3D748D9A4FAA1553646F0F74CA75 /* UIAutomationHelper.h */,
-				242535CC525ECF8690A37157D9EC84A6 /* UIAutomationHelper.m */,
-				6D8230543A4C9E0D5C22497D2ECDD1C7 /* UIEvent+KIFAdditions.h */,
-				CFBF2225597662620A87F5E89EF33B4F /* UIEvent+KIFAdditions.m */,
-				8D11E27C1926EA39B462D0B767612A4E /* UIScreen+KIFAdditions.h */,
-				8BD5F24D5CCABD1FA509BE921C30D445 /* UIScreen+KIFAdditions.m */,
-				42A1B7608BADE45C28DD7DF41F4381F4 /* UIScrollView-KIFAdditions.h */,
-				50EBBE738E53AB3C13BC526493BF7856 /* UIScrollView-KIFAdditions.m */,
-				FEDE285DA8F712F1C29352D8E93C11EF /* UITableView-KIFAdditions.h */,
-				C6AF22ACF146205542E0A07D2B89742E /* UITableView-KIFAdditions.m */,
-				B9F636F72FEA1335BD45123034E8F974 /* UITouch-KIFAdditions.h */,
-				5FB06D11E197EF0BDC986163FDFD5DAE /* UITouch-KIFAdditions.m */,
-				BE99D8916BC19E2C10B5D85E5C8F33BD /* UIView-Debugging.h */,
-				CA27611EF205EA16929BE6D445AE5A61 /* UIView-Debugging.m */,
-				E79809103F227854DA7A9AA658EB7106 /* UIView-KIFAdditions.h */,
-				389BBB72F897155429AF6867B03B6F0F /* UIView-KIFAdditions.m */,
-				B882456D2FCBE9ECC9AAC357C8DB5D14 /* UIWindow-KIFAdditions.h */,
-				BADD98F9AE8DA8490F2F061552CB9B60 /* UIWindow-KIFAdditions.m */,
-				7E4835B4B663E36574CA2B5ED4A8BDDE /* XCTestCase-KIFAdditions.h */,
-				E8D6EFD685C21E3A6FA8674ECE1B38BA /* XCTestCase-KIFAdditions.m */,
+				E2A86B6D1842B348AD599F343A7618D7 /* CAAnimation+KIFAdditions.h */,
+				29998B1C83CF1353932885487FA87E55 /* CAAnimation+KIFAdditions.m */,
+				6A1F05556841D38228A95FCFD0B1AA5F /* CALayer-KIFAdditions.h */,
+				2C437DF83D3678232026C72E05C16175 /* CALayer-KIFAdditions.m */,
+				E873F20D3342C2BF27D8BAF24630D1CA /* CGGeometry-KIFAdditions.h */,
+				7B07361F916AC43769A3654D7B05A3E7 /* CGGeometry-KIFAdditions.m */,
+				8479B8B4FA726F58EF98CF614BADB1C8 /* IOHIDEvent+KIF.h */,
+				1733BDF9134BF6748003424ACA210E9C /* IOHIDEvent+KIF.m */,
+				A9FC0111911F91B4B3633785129A44EF /* KIF.h */,
+				5F07EA44B20310380C2D2AC2A0A49700 /* KIFAccessibilityEnabler.h */,
+				FF7A4A1C3FAEE1F78712067B580CFEA6 /* KIFAccessibilityEnabler.m */,
+				0D5FCFAF0D919A05EAF4D9CD89A5B52B /* KIFSystemTestActor.h */,
+				151518AF274D7B5563E21402EE88AB43 /* KIFSystemTestActor.m */,
+				EA6F1D3242408C554EB696E3246C5425 /* KIFTestActor.h */,
+				96C73F729A165741634A0DE2025D9EC6 /* KIFTestActor.m */,
+				2110388300356A68BC40BFAAAD211494 /* KIFTestActor_Private.h */,
+				59293049DB68A9CFE017936B9D71F2A1 /* KIFTestCase.h */,
+				A8A77E97D7F4C0E843CB4B3D2991F502 /* KIFTestCase.m */,
+				FB44C47791414A455E267E8891F8B68B /* KIFTestStepValidation.h */,
+				50280113E17E0218C87036706C0401A1 /* KIFTestStepValidation.m */,
+				4FDA604BF363ECAA962F96DB56F18EFD /* KIFTextInputTraitsOverrides.h */,
+				5074A5530834DEC79BD80C045CE6C318 /* KIFTextInputTraitsOverrides.m */,
+				0628C7508D9B470AC9CD580FE62C1576 /* KIFTypist.h */,
+				0BBCE8CB3B7020F39234BD0E66AC7730 /* KIFTypist.m */,
+				EEDA80244BF2D570DC3C97F1D1074C95 /* KIFUIObject.h */,
+				C1B5BE9854D2A4C595E9202CD6A00E07 /* KIFUIObject.m */,
+				7697DDA6C6D9D87F9A980B8B157429C3 /* KIFUITestActor.h */,
+				2C5D0C6B5C2D53C77FDD91058B39768C /* KIFUITestActor.m */,
+				17283AB5B6D087C8561522349235F7C2 /* KIFUITestActor-ConditionalTests.h */,
+				F3098C8519EE5AF9DDE725384502A6C1 /* KIFUITestActor-ConditionalTests.m */,
+				2ACE6DF3A25F0EAEC9C796E37356B60F /* KIFUITestActor_Private.h */,
+				E1F2A72BE90AF2CB286A2E020E8C865A /* KIFUIViewTestActor.h */,
+				33C31ABE1AEF1452985D106AE9FA36CA /* KIFUIViewTestActor.m */,
+				65FCE101BA6858E3A0D2583689E71B9B /* LoadableCategory.h */,
+				045631F0B93D8D1FA2584AB11FB94E6F /* NSBundle-KIFAdditions.h */,
+				842492CB1AC0B4E5D6D7DFEE33F41FBD /* NSBundle-KIFAdditions.m */,
+				83C55DA82A69EE9C2B3F21408133B34C /* NSError-KIFAdditions.h */,
+				A6B10EE802DA2A88FE0BF6A6A9A60F8B /* NSError-KIFAdditions.m */,
+				588A84EBF6E4626961568D6F5C8510FB /* NSException-KIFAdditions.h */,
+				47805D74E14B19FB9C15DE43425C4309 /* NSException-KIFAdditions.m */,
+				31A8FA141DEE9ACB87524A9278292C9E /* NSFileManager-KIFAdditions.h */,
+				D28B0744F904025A3F206E815BF09DEE /* NSFileManager-KIFAdditions.m */,
+				1DCED89A51BE779AF73349F7BEA43C20 /* NSPredicate+KIFAdditions.h */,
+				7AF1042957774E02A681A5371EAECD1F /* NSPredicate+KIFAdditions.m */,
+				1D3DAFAAB509AD7639094B6BBF3CAD63 /* NSString+KIFAdditions.h */,
+				C52BD3A6262DE52698132DFFB4F083E2 /* NSString+KIFAdditions.m */,
+				3418016153F5D176B9DB1E184B0DE146 /* UIAccessibilityElement-KIFAdditions.h */,
+				7294262BA948BA9031979409009917CE /* UIAccessibilityElement-KIFAdditions.m */,
+				854F92281C52D313E09054364985B3F2 /* UIApplication-KIFAdditions.h */,
+				44AC22A5FFB2B3AEF9F5B10B38E22AA7 /* UIApplication-KIFAdditions.m */,
+				12C0B8CD6FBBC70995B3F538FA11F845 /* UIAutomationHelper.h */,
+				541E67506E53B7B6A3D8656FB3A3658D /* UIAutomationHelper.m */,
+				34E174346EF518EF57D6970EB1DFD60E /* UIEvent+KIFAdditions.h */,
+				40A6E24EE3140BA74FCC95BD24334A3A /* UIEvent+KIFAdditions.m */,
+				7C90D6D5708BBCB067F6CD0F844367AD /* UIScreen+KIFAdditions.h */,
+				538BBDDC3B252DF7264E6A4E7BFB2B21 /* UIScreen+KIFAdditions.m */,
+				A774923F68A562D8B5E73138EB25B6B3 /* UIScrollView-KIFAdditions.h */,
+				6E555C713CC262BFDB7E64E16B225020 /* UIScrollView-KIFAdditions.m */,
+				5AE9FA8F23E882B18A648AB3435B8672 /* UITableView-KIFAdditions.h */,
+				C048D3CCBA504CFBB9FD426AA9BF6ED4 /* UITableView-KIFAdditions.m */,
+				21011118BE437CCF36D574B3B2CBAB58 /* UITouch-KIFAdditions.h */,
+				C2FEE1D005D3112F1D8D6B6745AE0787 /* UITouch-KIFAdditions.m */,
+				5734BB6D663D1A0FFB3A2741FBE8CA2B /* UIView-Debugging.h */,
+				51A35E91D78D246461515D0033E384C3 /* UIView-Debugging.m */,
+				4494072B5F328320B13EA6B772126744 /* UIView-KIFAdditions.h */,
+				7963DAD342448711DD63B8A5D3B341A9 /* UIView-KIFAdditions.m */,
+				6BB310251167202CD6D1B795EA47FBF6 /* UIWindow-KIFAdditions.h */,
+				28A3EF57781043041FB25E9FD58162E8 /* UIWindow-KIFAdditions.m */,
+				2664C9DB97286469AF27C2AE5F92AE89 /* XCTestCase-KIFAdditions.h */,
+				47C1BEF536910A3CDA231CA993468D16 /* XCTestCase-KIFAdditions.m */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -1012,183 +1012,183 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		32D5A8B72A219D3925A7CAEE1FECA644 /* Headers */ = {
+		18EB3EA10C1202A9AD87A74CD546B47B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFC01C8D7DFE8D2BB1470357E3E1F125 /* NSCalendar+VOKAL.h in Headers */,
-				9B98F74182A836E0633F03F75C1A9C69 /* NSNumberFormatter+VOKAL.h in Headers */,
-				50E6F5205C18211ED670CE7E790A892A /* NSPredicate+VOKAL.h in Headers */,
-				D35BD431D6286BA30D2EAB1C4A148B1C /* NSString+VOKValidation.h in Headers */,
-				4ECE3B3E3A3D29F9D6659D9A077F1ADC /* UIColor+VOKAL.h in Headers */,
-				5D5BD72B3F43A79EFCD7607CA98FCE22 /* UIView+VOKCircle.h in Headers */,
-				36D45731B2575D5842CF4FC09CB77A5F /* UIView+VOKDebug.h in Headers */,
-				53A6CF791A083A7C71E3FC50BC52BDE8 /* VOKIBHelpers.h in Headers */,
-				4108086AFFEAADC3CFC301AF58FED6D5 /* VOKKeyPathHelper.h in Headers */,
+				5770CB8B5A30D803234E5492BD0913EF /* NSCalendar+VOKAL.h in Headers */,
+				A95CEFFD16563829091B7BF584A60644 /* NSNumberFormatter+VOKAL.h in Headers */,
+				504964211EAA4E5D3EB4C0E61B48A87A /* NSPredicate+VOKAL.h in Headers */,
+				57F9F0F4B79DBC580EE1AD13E8F09341 /* NSString+VOKValidation.h in Headers */,
+				75DBA5C0E5B0BBB4CB4CE25F8FA92139 /* UIColor+VOKAL.h in Headers */,
+				244E8735ACF061A67FF2D9A64ED4E115 /* UIView+VOKCircle.h in Headers */,
+				EF12C10C9AD352B25FE29BB7A116B7D1 /* UIView+VOKDebug.h in Headers */,
+				5C93115E6995B423BEE2CC5C311AD260 /* VOKIBHelpers.h in Headers */,
+				4E614A29676750B8E54748437AA6AC2B /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0DA1C739EEDA5443060FF545C1185B62 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		508992EC9B07BAE792DE6C37B9DA66BE /* Headers */ = {
+		38EED2835020C100843FAD041DB9A5F0 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0E4758B58C47205E948D37B831F191DA /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F4EB351F443CF358A3FBA0302C71E388 /* Pods-VOKUtilities-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AE534F8F556DB5BF7DAD431E1D73F22F /* Headers */ = {
+		3CD3CA08100481985A520104784DA568 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6383B830171EAFC9BC4FC579420FBB4E /* Headers */ = {
+		54670059C9E358A0BFA535F990D17480 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32C9E5128545F24B904518BA0DE623A0 /* Pods-VOKUtilities-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5BAD015322C648A6B340BD9EDC3ECB3B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C50431EEE437B4074C49E6FF17A36151 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D04DF3754052FBCB47200157866F7BC6 /* NSCalendar+VOKAL.h in Headers */,
-				545B8F9462BE8315EE2C0222632F4C79 /* NSNumberFormatter+VOKAL.h in Headers */,
-				AA8168625D88368FCA12F68C413E277B /* NSPredicate+VOKAL.h in Headers */,
-				05F89AC90E1444F6C9FD8C3F95149365 /* NSString+VOKValidation.h in Headers */,
-				88C38E2BCB37DF864397E7D269E24CD6 /* UIColor+VOKAL.h in Headers */,
-				9F52629011C5A6B8627A9BAED5F3E933 /* VOKKeyPathHelper.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		ABDFF5D375F207E5C32366A9664CD82E /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AFC319AC88E6E204B87A578A4DFBAD2F /* Pods-VOKUtilities-Tests-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3B61A4B1F915CA5C863845A96C8169DF /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6B53017C033AF251065E7FB989AE0DC0 /* NSCalendar+VOKAL.h in Headers */,
-				27B114C6E5EE0D738339C91F390218DA /* NSNumberFormatter+VOKAL.h in Headers */,
-				EBDE4D7762E2352ADB1D5EFEAB67D5CB /* NSPredicate+VOKAL.h in Headers */,
-				5C82F8769E8F9413889F452D34A82783 /* NSString+VOKValidation.h in Headers */,
-				A1A1A9B28AC26AB37954962D279D4F7D /* VOKKeyPathHelper.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74C800D845D92493742E3CE1A95F37ED /* Headers */ = {
+		68764E48AFA25A2DF037E4F5BAE9847B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8D889ECB1B6044EC4732EC240D81678F /* Headers */ = {
+		73EE1414E6FB2198F0C739D543CD5096 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				69B1B81FE4F1C1705CBA7397ABB3E168 /* Pods-VOKUtilities-UITests-umbrella.h in Headers */,
+				F616C936209D5FF6F1633BAC21C15DAC /* NSCalendar+VOKAL.h in Headers */,
+				ECD1171EF20BE11A81607D5B22456F1F /* NSNumberFormatter+VOKAL.h in Headers */,
+				95FE1506A275C4977B08FD34B0E91441 /* NSPredicate+VOKAL.h in Headers */,
+				08CA2F747CB12754C5514B666319D663 /* NSString+VOKValidation.h in Headers */,
+				29DD15ABB74097A1C643DB7F9788A0B2 /* UIColor+VOKAL.h in Headers */,
+				E54401843E2E081F23B6016BB0912350 /* VOKKeyPathHelper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D22E50FBE57D326B186A324EF0EAF668 /* Headers */ = {
+		A489F15E2E25C9ED6182E9C8CEC92BDF /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F054410158494CA7FCB122E128AB807 /* NSCalendar+VOKAL.h in Headers */,
-				0E38022AB7351C5EA1B6465F29471420 /* NSNumberFormatter+VOKAL.h in Headers */,
-				9637627E0EF2E1E59C707F7F3A889298 /* NSPredicate+VOKAL.h in Headers */,
-				AC6BE6BB89B9303F1EAD6F87891AA3CF /* NSString+VOKValidation.h in Headers */,
-				34C78670698BC8B6203F33075BCB5C40 /* UIColor+VOKAL.h in Headers */,
-				2927B94469FA6A772BE96417BBDB6BEC /* UIView+VOKCircle.h in Headers */,
-				BAF37D6493B79D93C7ECB4DAEF82D381 /* UIView+VOKDebug.h in Headers */,
-				80EE8320C86CEAC8BA45989DF71ADEF0 /* UIViewController+VOKKeyboard.h in Headers */,
-				A1B42461096E3B8BAB5D309A1BFC84FC /* VOKAlertAction.h in Headers */,
-				0B064D60B3A726A01F6C9A4BBD22B063 /* VOKAlertHelper.h in Headers */,
-				E15B3917B6B8D84345744F8640B82C0E /* VOKEmailHelper.h in Headers */,
-				9B6B152612908302AF0927C7444CA4CB /* VOKIBHelpers.h in Headers */,
-				F07BFA220714E3FF660E0B6C6E819710 /* VOKKeyPathHelper.h in Headers */,
-				E13A997BD27610F3AFF8A753AC81B7E3 /* VOKNavigationHelper.h in Headers */,
-				AF3C558B32CA94D83341AF3FCDE44F67 /* VOKUtilities-umbrella.h in Headers */,
+				0611CAEE1DF6AF8AF75F92706953D7D4 /* Pods-VOKUtilities-Tests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5B68F571ACDF89A764EC29E2F19E00F7 /* Headers */ = {
+		AD700D6F3FEEA05F3288B5B71510B93E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				01F647DA723DF805171D67C9FF381900 /* CAAnimation+KIFAdditions.h in Headers */,
-				90262600EA6E11B485E700EB06598F79 /* CALayer-KIFAdditions.h in Headers */,
-				3B8A561710C975A4192F5B91D1405086 /* CGGeometry-KIFAdditions.h in Headers */,
-				9A5E80F240980A2C3402F5C4B8974D98 /* IOHIDEvent+KIF.h in Headers */,
-				22D7B75B2096C2821DC84666F17AA2BC /* KIF.h in Headers */,
-				7884DF392661787265649F65D63E82EA /* KIFAccessibilityEnabler.h in Headers */,
-				8AAC2D83149826670CB2C577515E96E4 /* KIFSystemTestActor.h in Headers */,
-				F06ACB0015E9F1B5D348137CAE13101D /* KIFTestActor.h in Headers */,
-				F26DF92974F8BA0815A02944F507E3BA /* KIFTestActor_Private.h in Headers */,
-				C9A166D1F900E4E535914D0C215D68AC /* KIFTestCase.h in Headers */,
-				6FD34928008742068105EFDCF7700F87 /* KIFTestStepValidation.h in Headers */,
-				9E8CCDB8F5994C86A505A0CE244A0FB7 /* KIFTextInputTraitsOverrides.h in Headers */,
-				0172F1A5EDF0BCCA3FC8E54673FD3D0C /* KIFTypist.h in Headers */,
-				38A4539B672BDCAFD50B10183B9ABEFD /* KIFUIObject.h in Headers */,
-				B6D6289B35DFE36984BC4FB61DB3F7AF /* KIFUITestActor-ConditionalTests.h in Headers */,
-				B1BFE1DF7C9C248E691E4870B0B342CE /* KIFUITestActor.h in Headers */,
-				96DF40488971615854221E339AD5C9F2 /* KIFUITestActor_Private.h in Headers */,
-				CBD1BBD6FFE0D439E272E1B4806A5D50 /* KIFUIViewTestActor.h in Headers */,
-				7AA3D0C150C3F088D06EFF6AF3AE0160 /* LoadableCategory.h in Headers */,
-				247878FCFB67096A63ADBB772756140A /* NSBundle-KIFAdditions.h in Headers */,
-				807EAD36938FB0EB73DFC67793592286 /* NSError-KIFAdditions.h in Headers */,
-				5466F029D83D54EB8C8242796AEEB7A3 /* NSException-KIFAdditions.h in Headers */,
-				4C9B65F383FA58F1D86622D45AF8BE8B /* NSFileManager-KIFAdditions.h in Headers */,
-				E51C1AE7DE3F7B3D7AAEA17047D00954 /* NSPredicate+KIFAdditions.h in Headers */,
-				F05A20F4FA23663CC27FE5ACB39777BE /* NSString+KIFAdditions.h in Headers */,
-				CFA917AD4E4A400C843A8C1BFD74C915 /* UIAccessibilityElement-KIFAdditions.h in Headers */,
-				B25ED186BF5F151D6A3D3D4EDB6D9A31 /* UIApplication-KIFAdditions.h in Headers */,
-				08CB8C86F6D40F62A21BEDBE3EE86D57 /* UIAutomationHelper.h in Headers */,
-				3D4433329A24C85601B7622C5E8177F4 /* UIEvent+KIFAdditions.h in Headers */,
-				39495A2800FE60E9ED8F70C27306BC76 /* UIScreen+KIFAdditions.h in Headers */,
-				24527F943882460B0EE1961DCC87B42F /* UIScrollView-KIFAdditions.h in Headers */,
-				606DBE2CA6313FF657B9B006B3742277 /* UITableView-KIFAdditions.h in Headers */,
-				5A45A0BAE7DB8985A49FE3BA3A86E384 /* UITouch-KIFAdditions.h in Headers */,
-				DA4AC5591C05DEA48164EE2654701871 /* UIView-Debugging.h in Headers */,
-				F3B963CBF4E4E259DD9E874FCB15775B /* UIView-KIFAdditions.h in Headers */,
-				CEE2F2FB182D1701E065DD687658839C /* UIWindow-KIFAdditions.h in Headers */,
-				CBD899A67F601AF4CD3AFCA469A80A97 /* XCTestCase-KIFAdditions.h in Headers */,
+				F9ED1B0D8BEDF210853D58B6B08564E0 /* NSCalendar+VOKAL.h in Headers */,
+				3348D6408C82798BEC8CDF5B2F85F9C4 /* NSNumberFormatter+VOKAL.h in Headers */,
+				F6062079B0E8BDBCD2B05EB1EEDBF7BE /* NSPredicate+VOKAL.h in Headers */,
+				EE6CF6FE1A7BA635436AD858F756125C /* NSString+VOKValidation.h in Headers */,
+				072B93A6C679291D15A6347CC78E34F4 /* VOKKeyPathHelper.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D545EAABEDA8398AFF5E9B74FA46B504 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB03E8D51CFC776F20C4249BED0CB98A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				16894F3F6CA6A4DB6EE2F26948ADF571 /* Pods-VOKUtilities-UITests-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F32DF16C5520B7CE89107F93962F07B9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F60C457213A3898FBEE96C79F99A2C5 /* NSCalendar+VOKAL.h in Headers */,
+				3313734EA89F7EC8C2D94194E936B84E /* NSNumberFormatter+VOKAL.h in Headers */,
+				472B794958E1C15F5525D65652BF29B4 /* NSPredicate+VOKAL.h in Headers */,
+				8CD1335B07EFF294001EEDDE9F164C12 /* NSString+VOKValidation.h in Headers */,
+				955E77D04F2E7A708EBA752EF3FF8130 /* UIColor+VOKAL.h in Headers */,
+				0D09EA687E3247692ECBC7F87B29C375 /* UIView+VOKCircle.h in Headers */,
+				65F6C045E93013601945767BB65FB59C /* UIView+VOKDebug.h in Headers */,
+				3A7C35D799BF06DFB5A3FCA328007752 /* UIViewController+VOKKeyboard.h in Headers */,
+				2E4965E503AF1C511ADC6D7C6B4F9933 /* VOKAlertAction.h in Headers */,
+				8D6CD32E6BFD162D9146ED144069C62F /* VOKAlertHelper.h in Headers */,
+				727DE9FFBECCD18CB3BFDAE193F1DB3C /* VOKEmailHelper.h in Headers */,
+				C72BCEDA013D5FE383FD8AD4809A879E /* VOKIBHelpers.h in Headers */,
+				D491E20BE180269B324A5B91406E6D72 /* VOKKeyPathHelper.h in Headers */,
+				1100D998695377094CC5C38F1FEDDDC9 /* VOKNavigationHelper.h in Headers */,
+				A8BA5A8EDC7357BB61937F1EC0FD7801 /* VOKUtilities-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F66F886D854B18E214BD76DB8B77CE5C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5150B5579B19DE3D61047E30C09CDD22 /* CAAnimation+KIFAdditions.h in Headers */,
+				2182A60D0D5D40212A831F32122020FB /* CALayer-KIFAdditions.h in Headers */,
+				D19407A808D8145667DFF3B1A836E64C /* CGGeometry-KIFAdditions.h in Headers */,
+				7274809D7B27EB21EBEDC478A30A56C8 /* IOHIDEvent+KIF.h in Headers */,
+				0C998E08632DC5ED2B50CBCBDD0F3C9B /* KIF.h in Headers */,
+				BC1A9CB30616230A9A6F45AEE6FD1B33 /* KIFAccessibilityEnabler.h in Headers */,
+				95BB13FA72195BD7C3CA4E7516DF8B09 /* KIFSystemTestActor.h in Headers */,
+				94C099A22B94FC034BE41EAD078873CC /* KIFTestActor.h in Headers */,
+				2792749A0345F5691039C59716EEC634 /* KIFTestActor_Private.h in Headers */,
+				FCF0867F51700338CEBB3D0B05B01062 /* KIFTestCase.h in Headers */,
+				87F588E29193866FB8E5378971E07BC0 /* KIFTestStepValidation.h in Headers */,
+				3842D677146F399787E910C525F03257 /* KIFTextInputTraitsOverrides.h in Headers */,
+				1BFAD4ADF50F22C372B1E7244313BBFA /* KIFTypist.h in Headers */,
+				A7ED4E297A0894439DBEFF110B9AE2A4 /* KIFUIObject.h in Headers */,
+				B831AA84D91D95D36263A591FB237F1F /* KIFUITestActor-ConditionalTests.h in Headers */,
+				0AE31ACBCCE9A2707996ADE884F666CF /* KIFUITestActor.h in Headers */,
+				CBC7420555649F358AFB44FFA8B7E780 /* KIFUITestActor_Private.h in Headers */,
+				ACFA1EEF02C6E9C435ADCD46FA27FA05 /* KIFUIViewTestActor.h in Headers */,
+				B7E6A8C6D565C740CB26D7B44867209E /* LoadableCategory.h in Headers */,
+				E1FA3022843EEDCD4E5AA6757054C557 /* NSBundle-KIFAdditions.h in Headers */,
+				19606BD5186D80F8F61C1D443937F7BF /* NSError-KIFAdditions.h in Headers */,
+				73EE6413F89D5DED331A26E6A3E2C07B /* NSException-KIFAdditions.h in Headers */,
+				3010B47B6BCA1F998BC7B7177149BCA5 /* NSFileManager-KIFAdditions.h in Headers */,
+				0CD7D25C5E26C4F85227489B9291E5AC /* NSPredicate+KIFAdditions.h in Headers */,
+				5E7EDD5BF37E2A1542FE5788E22FA2D0 /* NSString+KIFAdditions.h in Headers */,
+				231A9B39B9757C75ABD0E00847121911 /* UIAccessibilityElement-KIFAdditions.h in Headers */,
+				0725F1ED5316A20F9E260C3CC74CF568 /* UIApplication-KIFAdditions.h in Headers */,
+				2B9BD8A97C3B2C65964FE148C4DA0147 /* UIAutomationHelper.h in Headers */,
+				80E608893F016FF54B56E00898C53CCC /* UIEvent+KIFAdditions.h in Headers */,
+				E889D9F2EAF028AA7B15FC03D6460740 /* UIScreen+KIFAdditions.h in Headers */,
+				0C24C52EF8992C938F044B1E72CEFBE1 /* UIScrollView-KIFAdditions.h in Headers */,
+				74A84094A7EBB52107F68DA5E70B8F5C /* UITableView-KIFAdditions.h in Headers */,
+				39D8A5A0C9CAD791D2141C7E6D9316F9 /* UITouch-KIFAdditions.h in Headers */,
+				8050B464C77CDC1B3627F7504E410392 /* UIView-Debugging.h in Headers */,
+				A279E04B38CFD7A58D4AF239204C3D73 /* UIView-KIFAdditions.h in Headers */,
+				6C55F29BE4925B80E048109C2D2D4410 /* UIWindow-KIFAdditions.h in Headers */,
+				978E15EE907FC6389523D84A5ED948E0 /* XCTestCase-KIFAdditions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */ = {
+		34041BF58915475CECBF7974837EFFB1 /* VOKUtilities */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BFEF623AB493671B39040FD1DBA758AE /* Build configuration list for PBXNativeTarget "VOKUtilities" */;
+			buildConfigurationList = 636CD395F9E1F15BCE729FD6B5FCD30E /* Build configuration list for PBXNativeTarget "VOKUtilities" */;
 			buildPhases = (
-				D22E50FBE57D326B186A324EF0EAF668 /* Headers */,
-				530EC35663471E8D1147EC79301EEE0C /* Sources */,
-				D1E0A78515A425ACB73FFF1E5DED5776 /* Frameworks */,
-				46FAB356A19DC0D710EC3C56CBA3ACAC /* Copy generated compatibility header */,
+				F32DF16C5520B7CE89107F93962F07B9 /* Headers */,
+				F33EC9D412ABDAA0AF693CCF49E33D95 /* Sources */,
+				6CCD7E53AAC839DFA9F4E4FAE796441B /* Frameworks */,
+				45E4990BFF011CACCF1841F1D4AD4942 /* Copy generated compatibility header */,
 			);
 			buildRules = (
 			);
@@ -1196,52 +1196,52 @@
 			);
 			name = VOKUtilities;
 			productName = VOKUtilities;
-			productReference = F1F509176F65E2C991E7C9308802DB84 /* libVOKUtilities.a */;
+			productReference = E51AFD8212C6F6786C56EACF2B507253 /* libVOKUtilities.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		1EB4FBF5D199665EB39C88FA3FB70DE8 /* Pods-VOKUtilities-Tests */ = {
+		59A65841DA6B3FB45A9655560925712B /* Pods-VOKUtilities-Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 900ADBC95F05BF1913234B3BAD9EBCF3 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-Tests" */;
+			buildConfigurationList = AE38973CE906E7F6DBC1F565324BB585 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-Tests" */;
 			buildPhases = (
-				ABDFF5D375F207E5C32366A9664CD82E /* Headers */,
-				553092B7C6C9617507AFA512DA665203 /* Sources */,
-				8CCF8A2AB3DC98B6D2EF4709D1B8237B /* Frameworks */,
+				A489F15E2E25C9ED6182E9C8CEC92BDF /* Headers */,
+				5F4208E32C2E2493CC33CD52974A6DFD /* Sources */,
+				C7D4CEDCD66751D5AD04C122302083AD /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				9CA2A4D1DAE7E5B568B8C78E5B95785F /* PBXTargetDependency */,
+				197E3E2895C8677ED628C81725BB83E9 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-Tests";
 			productName = "Pods-VOKUtilities-Tests";
-			productReference = BC8DA6D0DF596D1B39DDDFB944ACA263 /* libPods-VOKUtilities-Tests.a */;
+			productReference = CF7FC0370196B29F9A66BC2D86BE2DFD /* libPods-VOKUtilities-Tests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		A06A6CC5740B3AEB9784BB4540D13203 /* Pods-VOKUtilities-OSX */ = {
+		5AC1A498BC00147010DFCE91270561F7 /* Pods-VOKUtilities-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B9BAE4363822247CC25D199794E9A8F0 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX" */;
+			buildConfigurationList = 4C12E3EFDF0133BF7642E9AD48325B8E /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX" */;
 			buildPhases = (
-				74C800D845D92493742E3CE1A95F37ED /* Headers */,
-				5812D4BA6FCA89FAC1406B19938E4B94 /* Sources */,
-				348B2461B5E35D82E3EB9B693A51811B /* Frameworks */,
+				D545EAABEDA8398AFF5E9B74FA46B504 /* Headers */,
+				041018370419B09F60439413E235CF57 /* Sources */,
+				6C7FEC29E044F342EB48C89804FFC0A6 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				EE70CD6CB86152E0AF71A2DE0E2058AE /* PBXTargetDependency */,
+				2A9FE2ED7DF4F3F70C02206130F770F5 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-OSX";
 			productName = "Pods-VOKUtilities-OSX";
-			productReference = 0EF5C3FEB1E5D96EC3D465DC08AF03E0 /* libPods-VOKUtilities-OSX.a */;
+			productReference = 0323B2E7B3935FD08D198AD047C5EE5F /* libPods-VOKUtilities-OSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		8408DDD7AD3411FF55AF08891D7BC367 /* VOKUtilities-3288a73d */ = {
+		5F11AA50ACF05F346CDA77439859B6DA /* VOKUtilities-3288a73d */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D6E7166B6CA1362E3D88A00035EB8E9C /* Build configuration list for PBXNativeTarget "VOKUtilities-3288a73d" */;
+			buildConfigurationList = AA37849DD7156BF340745ADC37DB9CF8 /* Build configuration list for PBXNativeTarget "VOKUtilities-3288a73d" */;
 			buildPhases = (
-				3B61A4B1F915CA5C863845A96C8169DF /* Headers */,
-				ED783D70558B4D6DA62ADC2B52F53D4E /* Sources */,
-				2ABA41855DDC665A6AAD6B07798809AD /* Frameworks */,
+				AD700D6F3FEEA05F3288B5B71510B93E /* Headers */,
+				C36A3A443B261F40F78D33C0ACAB31EF /* Sources */,
+				EFE2149A9DC02001EE3800583AE13856 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1249,34 +1249,34 @@
 			);
 			name = "VOKUtilities-3288a73d";
 			productName = "VOKUtilities-3288a73d";
-			productReference = 1DA0DBDAC8F6E17E4219EC784294DE16 /* libVOKUtilities-3288a73d.a */;
+			productReference = 757DC2EBFACA2FDDD756AEAC3298FD09 /* libVOKUtilities-3288a73d.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		57BD5AF2872C00EC1387E1557367FCF9 /* Pods-VOKUtilities-tvOS */ = {
+		69D51ECFD86A12F3E397C96103F050D8 /* Pods-VOKUtilities-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1A9B60F2BF33F98364309DA4E4EB66D7 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS" */;
+			buildConfigurationList = E62ACB7337DA6B8EAE75FF3DA1FB26D7 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS" */;
 			buildPhases = (
-				0DA1C739EEDA5443060FF545C1185B62 /* Headers */,
-				43E0480B65DFEC5032DA0A0F88C73E56 /* Sources */,
-				012F6BB038ACBFCFA5F3AF5C3431DD93 /* Frameworks */,
+				38EED2835020C100843FAD041DB9A5F0 /* Headers */,
+				14985D1E064328AF28E7AD2413FDE9A0 /* Sources */,
+				A8197AE3E7886F0B1279EF4C2027E733 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				956191F3C7BF2C98097B76880853374F /* PBXTargetDependency */,
+				5DCE3358A13F0A04591487744DB31A31 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-tvOS";
 			productName = "Pods-VOKUtilities-tvOS";
-			productReference = 485C9F17FB14C43CB2B71C519FEF526A /* libPods-VOKUtilities-tvOS.a */;
+			productReference = AB89795847149BFD57F40652E55F4666 /* libPods-VOKUtilities-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		99C2EE2358EE6808D004D553CCB17A0D /* KIF */ = {
+		82B5B837E11665D1EEE2588148E3C1A7 /* KIF */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 4F620C182733A2CD75D5FC38627C9104 /* Build configuration list for PBXNativeTarget "KIF" */;
+			buildConfigurationList = 0924E574E064C5B5BAED3A4A3FB50D16 /* Build configuration list for PBXNativeTarget "KIF" */;
 			buildPhases = (
-				5B68F571ACDF89A764EC29E2F19E00F7 /* Headers */,
-				A0EFF1DA5F9837662A34FF04FE6C5622 /* Sources */,
-				6A617ACE89E98C028849DE07EDE9320A /* Frameworks */,
+				F66F886D854B18E214BD76DB8B77CE5C /* Headers */,
+				3AF2A4BA42C7E0D6E150E08B9D76D2A8 /* Sources */,
+				79D9411EB5585D447605082B13FBA498 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1284,16 +1284,16 @@
 			);
 			name = KIF;
 			productName = KIF;
-			productReference = 9F9D430B6941C0F4D78D8E7C77199599 /* libKIF.a */;
+			productReference = E1079F5001C1EE90DDC9BCC4B7837489 /* libKIF.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		D66B399E182882255B61F0D42ED65BDC /* VOKUtilities-6aa4e1e5 */ = {
+		94DBDDEF06EFF716048EEF3645387066 /* VOKUtilities-6aa4e1e5 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DDEB6851C10F50F34FC0FD1C6951E499 /* Build configuration list for PBXNativeTarget "VOKUtilities-6aa4e1e5" */;
+			buildConfigurationList = 5FAF5E3D34E07A0623964CFA68A6A314 /* Build configuration list for PBXNativeTarget "VOKUtilities-6aa4e1e5" */;
 			buildPhases = (
-				C50431EEE437B4074C49E6FF17A36151 /* Headers */,
-				A0E1BB0F5298F26DD004C74A2A5F4E50 /* Sources */,
-				1A5DDBFD1A2CB455FD693EB0F49DEFDD /* Frameworks */,
+				73EE1414E6FB2198F0C739D543CD5096 /* Headers */,
+				12C2AFF497DF43FB2E37277DF37ED5AD /* Sources */,
+				3BE23949C86917D1F5161C8567A2A009 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1301,16 +1301,16 @@
 			);
 			name = "VOKUtilities-6aa4e1e5";
 			productName = "VOKUtilities-6aa4e1e5";
-			productReference = 5AB028AA13C5B05486B99715DE144FA1 /* libVOKUtilities-6aa4e1e5.a */;
+			productReference = 308B8869DF208C08C36B1785FDEE019F /* libVOKUtilities-6aa4e1e5.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		7FED5C7AEFE8FA987C032F83E89A51C3 /* VOKUtilities-d8783a65 */ = {
+		986D4576ACB401B6E7833D76875E6E80 /* VOKUtilities-d8783a65 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 5E13B445FF39DB0EC6ACAFA037124CFE /* Build configuration list for PBXNativeTarget "VOKUtilities-d8783a65" */;
+			buildConfigurationList = D843D5D60CE6977DE337553CCF254D0E /* Build configuration list for PBXNativeTarget "VOKUtilities-d8783a65" */;
 			buildPhases = (
-				32D5A8B72A219D3925A7CAEE1FECA644 /* Headers */,
-				95253C5862C35E6B0B5BA473336D7349 /* Sources */,
-				B95CFCDB154F3E721E83996D2954964D /* Frameworks */,
+				18EB3EA10C1202A9AD87A74CD546B47B /* Headers */,
+				4293CA2A3CAED3A84347ADC2FB9D94F1 /* Sources */,
+				DC6589C22689019A080EE1848ECEDCB0 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1318,98 +1318,98 @@
 			);
 			name = "VOKUtilities-d8783a65";
 			productName = "VOKUtilities-d8783a65";
-			productReference = BC1831D9749CA200885645CFCF267C6C /* libVOKUtilities-d8783a65.a */;
+			productReference = A1F46A1672C999E6E7F27CC368D40F9F /* libVOKUtilities-d8783a65.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		0026DE30394AFA54D09FEE27B4035EEB /* Pods-VOKUtilities-UITests */ = {
+		BB761C275423DCE63D3C8CE8B1073C80 /* Pods-VOKUtilities-UITests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 58DF8DC0CDA164F0894EAC570B005B45 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-UITests" */;
+			buildConfigurationList = DEDB9E162120CF1B5A497E018845A89D /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-UITests" */;
 			buildPhases = (
-				8D889ECB1B6044EC4732EC240D81678F /* Headers */,
-				9199CE4A1B58429F2AA8A5501BB117E2 /* Sources */,
-				7EB7687573C25C4A3D6A3317BE7DB9F6 /* Frameworks */,
+				DB03E8D51CFC776F20C4249BED0CB98A /* Headers */,
+				66E8F5C9293AA3F1D1E57469EBA2212C /* Sources */,
+				270A1EF9610EA8047D0A6EDE920DB68A /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				8B3D2AF7153FB2AD4103CCA95C99AA56 /* PBXTargetDependency */,
-				5F53E2E296A0207EABF78A78A0FF7114 /* PBXTargetDependency */,
+				C752E87EB936BDBECE70018E5AE377C1 /* PBXTargetDependency */,
+				2D506C590D7D544AC1EBE459F3942BD2 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-UITests";
 			productName = "Pods-VOKUtilities-UITests";
-			productReference = 9D2CBBE22941DDAB01BE14CA7FB26D60 /* libPods-VOKUtilities-UITests.a */;
+			productReference = 8800680AA42C25DA643210E051BD64C2 /* libPods-VOKUtilities-UITests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		8577A590994AE2F45F72AE8DB7CF9456 /* Pods-VOKUtilities */ = {
+		C3DCCDA02FF7F1C17173662ACA7FCBF5 /* Pods-VOKUtilities */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F053C8D2DE88FE93A7718783E1C403FC /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities" */;
+			buildConfigurationList = D4EF0495899156912BE651C31EEEE651 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities" */;
 			buildPhases = (
-				0E4758B58C47205E948D37B831F191DA /* Headers */,
-				B68E37D4E404042114ED7B8800912C00 /* Sources */,
-				DB77D48845F8C177DAD98AACE395951B /* Frameworks */,
+				54670059C9E358A0BFA535F990D17480 /* Headers */,
+				1B263BA8F6EB8B146F6CECC8F7AF7571 /* Sources */,
+				448B058306DACEFE16BC39BE0306BCA5 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C8C781A1B69FB78302B30EA54F300B5D /* PBXTargetDependency */,
+				08538D7DF4DF25C7B6D40DFAF7034FEE /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities";
 			productName = "Pods-VOKUtilities";
-			productReference = 2027DDAB90D2F6D9748A850FF1468A8B /* libPods-VOKUtilities.a */;
+			productReference = AC85B484287AB5C191B492814CE5B59A /* libPods-VOKUtilities.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		F02811030D3157C5547A099B434560B1 /* Pods-VOKUtilities-OSX-Tests-OSX */ = {
+		D02E047C21796D15A84797199FF65D90 /* Pods-VOKUtilities-OSX-Tests-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E1972B2D3E669C45DA7B174A2F5ACA3D /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX-Tests-OSX" */;
+			buildConfigurationList = C2D98EDF7CB5F8045FFFD96C38268A99 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX-Tests-OSX" */;
 			buildPhases = (
-				6383B830171EAFC9BC4FC579420FBB4E /* Headers */,
-				E20FB45EBA6428EE9259E5BA00E654CE /* Sources */,
-				BE760AFCFA49A18172914D68CC12DA2C /* Frameworks */,
+				68764E48AFA25A2DF037E4F5BAE9847B /* Headers */,
+				06A74F9362676AFF9897A42527BBC730 /* Sources */,
+				585987FA1407B4C2135286BC140C7827 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C0BB008BFBDF0A9AF5745AC88722FFA9 /* PBXTargetDependency */,
+				E0FDDCA69DD56EE31614AB2E6067AEAE /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-OSX-Tests-OSX";
 			productName = "Pods-VOKUtilities-OSX-Tests-OSX";
-			productReference = 1EA2E4CE4A681ADC33B94043FB65AEE7 /* libPods-VOKUtilities-OSX-Tests-OSX.a */;
+			productReference = 936B509B358510D3EADBF473EAA85AC2 /* libPods-VOKUtilities-OSX-Tests-OSX.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		4EC8A1B5C37DB4DC6A4B782D2D33BF5C /* Pods-VOKUtilities-watchOS Extension */ = {
+		D376E54E739C2BCCAA33207EA3105A7C /* Pods-VOKUtilities-watchOS Extension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 47FF61D2CE026D18CC038CBBAF01EE5E /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-watchOS Extension" */;
+			buildConfigurationList = 60CCD58F2FAAC1A17DB1E94BF0EDCC5F /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-watchOS Extension" */;
 			buildPhases = (
-				AE534F8F556DB5BF7DAD431E1D73F22F /* Headers */,
-				73019C01879A33EBF1BAC4ACED8261FD /* Sources */,
-				D223291F293640B7A3C216FC67088B15 /* Frameworks */,
+				5BAD015322C648A6B340BD9EDC3ECB3B /* Headers */,
+				9B4C604A8FEC55A83D1839B8A7F27DB4 /* Sources */,
+				42454B7BD5D29905FACA60026AEEA3BF /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				88B347F0FB622E4EE4A85AF9A1459C7C /* PBXTargetDependency */,
+				BF5B7BFF62FC82DC9DF1962D4A57BFE5 /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-watchOS Extension";
 			productName = "Pods-VOKUtilities-watchOS Extension";
-			productReference = 0BA9E8381AD94FC457CA0FE358F99BAC /* libPods-VOKUtilities-watchOS Extension.a */;
+			productReference = FAE725F274AABEA1C96774248F696C44 /* libPods-VOKUtilities-watchOS Extension.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		FBECD0F5C69F21F3C4A883183F42260C /* Pods-VOKUtilities-tvOS-Tests-tvOS */ = {
+		E6D69754ADA8EE4940F6744CCFF2384D /* Pods-VOKUtilities-tvOS-Tests-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 930AE6E527753812537FF661A0595C3B /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS-Tests-tvOS" */;
+			buildConfigurationList = 10ECE019846AACED1A6455676D7439ED /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS-Tests-tvOS" */;
 			buildPhases = (
-				508992EC9B07BAE792DE6C37B9DA66BE /* Headers */,
-				1260290B664BB20C4EF83505AA54287E /* Sources */,
-				202FB0DFE2796E987646C7A1B0AFA2A7 /* Frameworks */,
+				3CD3CA08100481985A520104784DA568 /* Headers */,
+				DDBFA2364CE4D91EBC23801A918D1E7B /* Sources */,
+				C4D6AF04DBF4220E78E55ABB1473C786 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				132821AE7F3482F5EB9CD991218BCE45 /* PBXTargetDependency */,
+				58BAD50D8AC777AED9D1B60DC25271DC /* PBXTargetDependency */,
 			);
 			name = "Pods-VOKUtilities-tvOS-Tests-tvOS";
 			productName = "Pods-VOKUtilities-tvOS-Tests-tvOS";
-			productReference = D0DEF7D991C888FA2532FC5389298272 /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */;
+			productReference = 29C8F167BEDFA04DF429BC1FA428BF2B /* libPods-VOKUtilities-tvOS-Tests-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -1421,37 +1421,37 @@
 				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 1020;
 			};
-			buildConfigurationList = FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 5DECD2D2DDBCF1DF25E1166EAF85634C;
-			productRefGroup = F11F3D9AADDE75DD48B2D75FDE6D0F2A /* Products */;
+			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
+			productRefGroup = 5EB4D956D64EB040A5C21749E339DC18 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				99C2EE2358EE6808D004D553CCB17A0D /* KIF */,
-				8577A590994AE2F45F72AE8DB7CF9456 /* Pods-VOKUtilities */,
-				A06A6CC5740B3AEB9784BB4540D13203 /* Pods-VOKUtilities-OSX */,
-				F02811030D3157C5547A099B434560B1 /* Pods-VOKUtilities-OSX-Tests-OSX */,
-				1EB4FBF5D199665EB39C88FA3FB70DE8 /* Pods-VOKUtilities-Tests */,
-				57BD5AF2872C00EC1387E1557367FCF9 /* Pods-VOKUtilities-tvOS */,
-				FBECD0F5C69F21F3C4A883183F42260C /* Pods-VOKUtilities-tvOS-Tests-tvOS */,
-				0026DE30394AFA54D09FEE27B4035EEB /* Pods-VOKUtilities-UITests */,
-				4EC8A1B5C37DB4DC6A4B782D2D33BF5C /* Pods-VOKUtilities-watchOS Extension */,
-				7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */,
-				8408DDD7AD3411FF55AF08891D7BC367 /* VOKUtilities-3288a73d */,
-				D66B399E182882255B61F0D42ED65BDC /* VOKUtilities-6aa4e1e5 */,
-				7FED5C7AEFE8FA987C032F83E89A51C3 /* VOKUtilities-d8783a65 */,
+				82B5B837E11665D1EEE2588148E3C1A7 /* KIF */,
+				C3DCCDA02FF7F1C17173662ACA7FCBF5 /* Pods-VOKUtilities */,
+				5AC1A498BC00147010DFCE91270561F7 /* Pods-VOKUtilities-OSX */,
+				D02E047C21796D15A84797199FF65D90 /* Pods-VOKUtilities-OSX-Tests-OSX */,
+				59A65841DA6B3FB45A9655560925712B /* Pods-VOKUtilities-Tests */,
+				69D51ECFD86A12F3E397C96103F050D8 /* Pods-VOKUtilities-tvOS */,
+				E6D69754ADA8EE4940F6744CCFF2384D /* Pods-VOKUtilities-tvOS-Tests-tvOS */,
+				BB761C275423DCE63D3C8CE8B1073C80 /* Pods-VOKUtilities-UITests */,
+				D376E54E739C2BCCAA33207EA3105A7C /* Pods-VOKUtilities-watchOS Extension */,
+				34041BF58915475CECBF7974837EFFB1 /* VOKUtilities */,
+				5F11AA50ACF05F346CDA77439859B6DA /* VOKUtilities-3288a73d */,
+				94DBDDEF06EFF716048EEF3645387066 /* VOKUtilities-6aa4e1e5 */,
+				986D4576ACB401B6E7833D76875E6E80 /* VOKUtilities-d8783a65 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		46FAB356A19DC0D710EC3C56CBA3ACAC /* Copy generated compatibility header */ = {
+		45E4990BFF011CACCF1841F1D4AD4942 /* Copy generated compatibility header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1478,251 +1478,251 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		5812D4BA6FCA89FAC1406B19938E4B94 /* Sources */ = {
+		041018370419B09F60439413E235CF57 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7908AF6E7AFC63996CADF5DDF58CCB84 /* Pods-VOKUtilities-OSX-dummy.m in Sources */,
+				5F9CF4BF6451C918438382ACF5ABC5F7 /* Pods-VOKUtilities-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E20FB45EBA6428EE9259E5BA00E654CE /* Sources */ = {
+		06A74F9362676AFF9897A42527BBC730 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5032A786CD5F9A68C1C3FD443D92BCD0 /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m in Sources */,
+				6A65FF06F13304ABC3C13A5018AB760E /* Pods-VOKUtilities-OSX-Tests-OSX-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A0E1BB0F5298F26DD004C74A2A5F4E50 /* Sources */ = {
+		12C2AFF497DF43FB2E37277DF37ED5AD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EC0E2B80664BF8A9AAE0A297CEB56D33 /* NSCalendar+VOKAL.m in Sources */,
-				F3E2F56B5DC4EAA943FBA17C747605B0 /* NSNumberFormatter+VOKAL.m in Sources */,
-				1BAF1A82610C6A7EA23CEDF1AD9B4CE1 /* NSPredicate+VOKAL.m in Sources */,
-				7C667D251FEFF31C432C199B020103BF /* NSString+VOKValidation.m in Sources */,
-				2BAC762956CAA21254B8D5F2EC9D7B3E /* UIColor+VOKAL.m in Sources */,
-				D076EACCBC02C000FFD86673598E5932 /* VOKKeyPathHelper.m in Sources */,
-				FA8BE2AA35C4E58BA7A3CF4E711854C3 /* VOKUtilities-6aa4e1e5-dummy.m in Sources */,
+				8C9F53B16722BE8D752E99A25C7E9CE7 /* NSCalendar+VOKAL.m in Sources */,
+				33DA2D22C985733B632AD1F5F1FF0F29 /* NSNumberFormatter+VOKAL.m in Sources */,
+				883DF04D2A5EB62376A50B3FBC09024D /* NSPredicate+VOKAL.m in Sources */,
+				62E1F93B0D1FFA0FCE24FD3AD8A367B7 /* NSString+VOKValidation.m in Sources */,
+				F965F50D649F7751950B0B6EBE0A75CC /* UIColor+VOKAL.m in Sources */,
+				DE9ED8148CB62F377BF959D2A8FD7921 /* VOKKeyPathHelper.m in Sources */,
+				3E7669B7BEE459BCF0CAB8E9B7C00872 /* VOKUtilities-6aa4e1e5-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		43E0480B65DFEC5032DA0A0F88C73E56 /* Sources */ = {
+		14985D1E064328AF28E7AD2413FDE9A0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E6128F654A02F2B76201F5640466E167 /* Pods-VOKUtilities-tvOS-dummy.m in Sources */,
+				BF3502FFEFD84DFFF4B50B1F47E6E023 /* Pods-VOKUtilities-tvOS-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B68E37D4E404042114ED7B8800912C00 /* Sources */ = {
+		1B263BA8F6EB8B146F6CECC8F7AF7571 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				46163911E3FF99219AFCE2D4591461C6 /* Pods-VOKUtilities-dummy.m in Sources */,
+				6043A0A78D9A8B57B55EEDB875DD4E59 /* Pods-VOKUtilities-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A0EFF1DA5F9837662A34FF04FE6C5622 /* Sources */ = {
+		3AF2A4BA42C7E0D6E150E08B9D76D2A8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A9DE7819DD98FCBB04D5A282FC162CE /* CAAnimation+KIFAdditions.m in Sources */,
-				B0A8DFEBEFD9028A8C3C19D59576C2F9 /* CALayer-KIFAdditions.m in Sources */,
-				591BCA1983AFBCFF525C79889819723C /* CGGeometry-KIFAdditions.m in Sources */,
-				D8A874F13CDB9EBD8C3F7C355EF7A811 /* IOHIDEvent+KIF.m in Sources */,
-				ECCFD9DB93D87F5D0A8A2ADEDFE6B994 /* KIF-dummy.m in Sources */,
-				CE5EC9CE9AB6BD280AED17FC9E8E9623 /* KIFAccessibilityEnabler.m in Sources */,
-				0EEAD81094CC846DBB9DA8B97BCB4E1B /* KIFSystemTestActor.m in Sources */,
-				066BD2E7DC764467FEE88CB5B2FE0EBD /* KIFTestActor.m in Sources */,
-				CEC7D337688B6C9B8B2E5F47D1878D9E /* KIFTestCase.m in Sources */,
-				E06011C5667EFA4ED41367586E837272 /* KIFTestStepValidation.m in Sources */,
-				358714A0A234CFAB3C463917D357100A /* KIFTextInputTraitsOverrides.m in Sources */,
-				F919BA9052DD469B8E9D08EAE47DA74D /* KIFTypist.m in Sources */,
-				69AF46246434A86D579FE039025530C9 /* KIFUIObject.m in Sources */,
-				BDCA6C3F6A98F6F549D929D2984A50FB /* KIFUITestActor-ConditionalTests.m in Sources */,
-				D90DBFD60CF81E84BAB63DCEFB14DB10 /* KIFUITestActor.m in Sources */,
-				4426BEF72AEBC8DC956F1DB0BAAA1E9F /* KIFUIViewTestActor.m in Sources */,
-				C49E5B8D80835783BDBF62C7A00780A9 /* NSBundle-KIFAdditions.m in Sources */,
-				E74F64513F0EA4B6CEF83BFED8FCDD88 /* NSError-KIFAdditions.m in Sources */,
-				1E224705D276B60D3725B992F029097D /* NSException-KIFAdditions.m in Sources */,
-				956AA4463D87C338F52E4F33BF3CBF74 /* NSFileManager-KIFAdditions.m in Sources */,
-				C319D7EDB69A945CE3B5DA5275EBD046 /* NSPredicate+KIFAdditions.m in Sources */,
-				DF067A7AA245854D09F51F70D8FC9A6A /* NSString+KIFAdditions.m in Sources */,
-				58D78A7BE7583734693BE47FEF199053 /* UIAccessibilityElement-KIFAdditions.m in Sources */,
-				CA38D50548CA53EA677BC82C210974F6 /* UIApplication-KIFAdditions.m in Sources */,
-				C50599D6C20E63E13F25812A1A14BB05 /* UIAutomationHelper.m in Sources */,
-				98CA2CA038CD89DE48F8B16EBC579E55 /* UIEvent+KIFAdditions.m in Sources */,
-				0EC1E7C9C7D4FDF0A3C94184D8DBB593 /* UIScreen+KIFAdditions.m in Sources */,
-				ADF4BA7A1C019BDC2B26C2DFA9BB1BB0 /* UIScrollView-KIFAdditions.m in Sources */,
-				9F3C154AE74FDB6158FCDDBDECD7058C /* UITableView-KIFAdditions.m in Sources */,
-				0AF303A4B91FED23278F67F9ACE03E9E /* UITouch-KIFAdditions.m in Sources */,
-				338FA3D7A7C0397F2DF282D7461C9E44 /* UIView-Debugging.m in Sources */,
-				3259FDE0D6F1C166728055A875AB7F7A /* UIView-KIFAdditions.m in Sources */,
-				C19D35CFDCB329F018E223A0B7C9E5CD /* UIWindow-KIFAdditions.m in Sources */,
-				F98F90CC8C0EA4F72270660D674811C2 /* XCTestCase-KIFAdditions.m in Sources */,
+				8FAA6AB6DA9BFD572114AD156FC772A5 /* CAAnimation+KIFAdditions.m in Sources */,
+				5FF6E4275D74E2EE4BD4B9347A26B0C4 /* CALayer-KIFAdditions.m in Sources */,
+				D0CAAFC19EBE6056CE23E9EAB50C011D /* CGGeometry-KIFAdditions.m in Sources */,
+				30FD752D90381984ADB5A87B7591E3A1 /* IOHIDEvent+KIF.m in Sources */,
+				0B0971B545D372D0FA9D861BF2F8FD8C /* KIF-dummy.m in Sources */,
+				2BA5F8910999DE5D86399BC362704EFC /* KIFAccessibilityEnabler.m in Sources */,
+				3FE69190C5FB7292106727813FCDC791 /* KIFSystemTestActor.m in Sources */,
+				668AE6317D5CCF211BF02A144AEE9773 /* KIFTestActor.m in Sources */,
+				62FBC1EBDB0E804D04C2FABB20DF8442 /* KIFTestCase.m in Sources */,
+				CBC4D8FE5D5131AB88382B5C435490DF /* KIFTestStepValidation.m in Sources */,
+				EDB5ACE558B13D8340F5E4E4674EA7F8 /* KIFTextInputTraitsOverrides.m in Sources */,
+				2C5636799AE488754118E038194911DA /* KIFTypist.m in Sources */,
+				F399558B771479398EF0C3C64AB1368A /* KIFUIObject.m in Sources */,
+				372B6A052AFDF4B1D21DBCD3C46B4A1E /* KIFUITestActor-ConditionalTests.m in Sources */,
+				A6755A2D31E1190C0665360C7A944938 /* KIFUITestActor.m in Sources */,
+				32DCDEDBDEDDB4DC666E8B7BBA3143AE /* KIFUIViewTestActor.m in Sources */,
+				D6EDB021BCEF9A49F309DD04D945E73B /* NSBundle-KIFAdditions.m in Sources */,
+				86D5FD1FB7082A926BE2077D2F6FED71 /* NSError-KIFAdditions.m in Sources */,
+				4F621D0FE826BAF7C4779182BFC88688 /* NSException-KIFAdditions.m in Sources */,
+				D385BC7EF4C1663E3840DF195D894AD6 /* NSFileManager-KIFAdditions.m in Sources */,
+				E896CA96CB3C5AA3FCBA154AFAF7B267 /* NSPredicate+KIFAdditions.m in Sources */,
+				890C4244259B7ED1ADE33F3FAB8E85D2 /* NSString+KIFAdditions.m in Sources */,
+				FC0BB8CFCE30B53AF07223E5A9409BD1 /* UIAccessibilityElement-KIFAdditions.m in Sources */,
+				8EC68F180523EBDC9DBF6883F7863AD9 /* UIApplication-KIFAdditions.m in Sources */,
+				B2427CB25D09BC7A33A783EC7EFB5F1E /* UIAutomationHelper.m in Sources */,
+				D4731F8D605D29C076C130BF0C9BA138 /* UIEvent+KIFAdditions.m in Sources */,
+				0E439FDA88BF2E88ACC856500FCC0944 /* UIScreen+KIFAdditions.m in Sources */,
+				97382B37F557FD160C4D7DA00F96C47F /* UIScrollView-KIFAdditions.m in Sources */,
+				B028E4EFBBDD4836CFF6F80E55454B72 /* UITableView-KIFAdditions.m in Sources */,
+				0ADCC2F9A01259005F64E5D255E2852B /* UITouch-KIFAdditions.m in Sources */,
+				B5E170609650585C0A02F89941417231 /* UIView-Debugging.m in Sources */,
+				A294247DAF0C0FC7B76F6C2B07D91AB2 /* UIView-KIFAdditions.m in Sources */,
+				8C44C14D877C52CF94E44FC252BE4A8B /* UIWindow-KIFAdditions.m in Sources */,
+				2ABF8F457882F18C212ABD87FAAC608E /* XCTestCase-KIFAdditions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		95253C5862C35E6B0B5BA473336D7349 /* Sources */ = {
+		4293CA2A3CAED3A84347ADC2FB9D94F1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A64AF947B7079FD5F5D383C29FEFE99 /* NSCalendar+VOKAL.m in Sources */,
-				0DB6887BC743441845D8077845F54630 /* NSNumberFormatter+VOKAL.m in Sources */,
-				E9300FA1BAAAB9DF9D9624809BF57530 /* NSPredicate+VOKAL.m in Sources */,
-				4CB96E8F9061BC100585432DF7BA3BDA /* NSString+VOKValidation.m in Sources */,
-				3A7724FF69212242870A0843784D2F4D /* UIColor+VOKAL.m in Sources */,
-				A885D6DDE124A3BD9A225575CEB41E89 /* UIView+VOKCircle.m in Sources */,
-				CE29DA078A04020778906D0B6651CBBF /* UIView+VOKDebug.m in Sources */,
-				F3D309D9FAA8EFD8C0F062BD2C353739 /* VOKKeyPathHelper.m in Sources */,
-				FAD0588CDF835312E2C6B3A51BBB4054 /* VOKUtilities-d8783a65-dummy.m in Sources */,
+				1B80D4AD271FF2E0004A81BB038CFF9F /* NSCalendar+VOKAL.m in Sources */,
+				DC552B4224AB3A4587C50384BF9FFA76 /* NSNumberFormatter+VOKAL.m in Sources */,
+				EFAF22C600622334AE6A73B1465588D1 /* NSPredicate+VOKAL.m in Sources */,
+				276A03904A75CEE82AA6CF2E1820F1DD /* NSString+VOKValidation.m in Sources */,
+				FBECB8D1A53230B278F153377E6623BA /* UIColor+VOKAL.m in Sources */,
+				D401E25FD5ED818F050CBADC435981F9 /* UIView+VOKCircle.m in Sources */,
+				92D0257F35B144281ACD0AD7D2842740 /* UIView+VOKDebug.m in Sources */,
+				5A4A159F7CE7FA9BD7D3B0F7F4180464 /* VOKKeyPathHelper.m in Sources */,
+				FBF80CACD8AB40962A6896237FA2DC91 /* VOKUtilities-d8783a65-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		553092B7C6C9617507AFA512DA665203 /* Sources */ = {
+		5F4208E32C2E2493CC33CD52974A6DFD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1A1FDF849F33DD9C083217280BBED7D /* Pods-VOKUtilities-Tests-dummy.m in Sources */,
+				447B089C6AB266B5A46C611174491663 /* Pods-VOKUtilities-Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9199CE4A1B58429F2AA8A5501BB117E2 /* Sources */ = {
+		66E8F5C9293AA3F1D1E57469EBA2212C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A789BCC905B8D8D8CAB4582341DB19A4 /* Pods-VOKUtilities-UITests-dummy.m in Sources */,
+				AEAE2361860B3F768E61BF41C1318E88 /* Pods-VOKUtilities-UITests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		73019C01879A33EBF1BAC4ACED8261FD /* Sources */ = {
+		9B4C604A8FEC55A83D1839B8A7F27DB4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E32F063BB94CE0A5C84CA0332B8F2866 /* Pods-VOKUtilities-watchOS Extension-dummy.m in Sources */,
+				86E05146CFC8D414E715550894D95DC9 /* Pods-VOKUtilities-watchOS Extension-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ED783D70558B4D6DA62ADC2B52F53D4E /* Sources */ = {
+		C36A3A443B261F40F78D33C0ACAB31EF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BCE2DE51552B5839E09F8FB6FF7EDE4C /* NSCalendar+VOKAL.m in Sources */,
-				5BC481AF79C1C5A64B93E6FC8CD836E6 /* NSNumberFormatter+VOKAL.m in Sources */,
-				732CD8F6F271D11CB9A521157DC98B15 /* NSPredicate+VOKAL.m in Sources */,
-				4CD9D16E65744DF1547C3B53BA5B863E /* NSString+VOKValidation.m in Sources */,
-				5D77887AE928EAC6DD216A5A3648FAFE /* VOKKeyPathHelper.m in Sources */,
-				C818EBD8AA3C5BDBA657AAAD94ECDD08 /* VOKUtilities-3288a73d-dummy.m in Sources */,
+				EF4D50B2328A6B2D6839AD06768B123F /* NSCalendar+VOKAL.m in Sources */,
+				D210B1853E91CDF610CCD5B9066AC3FD /* NSNumberFormatter+VOKAL.m in Sources */,
+				599B300D3F770C23142920DEF270E032 /* NSPredicate+VOKAL.m in Sources */,
+				915D9C66AD5A3CC8FBDF173C64BA4FAB /* NSString+VOKValidation.m in Sources */,
+				E14827121891573EB32D02E1E4A4C126 /* VOKKeyPathHelper.m in Sources */,
+				B8C847ADC53B46887777AA683B9F1AEF /* VOKUtilities-3288a73d-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1260290B664BB20C4EF83505AA54287E /* Sources */ = {
+		DDBFA2364CE4D91EBC23801A918D1E7B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AD2F77A7D7ECF28C9872EF8C489FCC31 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m in Sources */,
+				4E294EC294512F4B27C518056D631DB7 /* Pods-VOKUtilities-tvOS-Tests-tvOS-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		530EC35663471E8D1147EC79301EEE0C /* Sources */ = {
+		F33EC9D412ABDAA0AF693CCF49E33D95 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B55E3658B4CF1E821AEC47ACE449CF2 /* CollectionExtensions.swift in Sources */,
-				DF75E92E93963F8695AFC1ABAD20F223 /* IntExtensions.swift in Sources */,
-				870D397E3E3A1020ACEDFF18A773F04C /* NSCalendar+VOKAL.m in Sources */,
-				877E40151BA3CE4DA240CDF7EF1D5E6A /* NSNumberFormatter+VOKAL.m in Sources */,
-				23AF6569C990137FB663D722C1F29C1C /* NSPredicate+VOKAL.m in Sources */,
-				2D59D4118E2B4FDD9AB45B3BA5E90444 /* NSString+VOKValidation.m in Sources */,
-				5FE9936CDA1D60F5C50EC93AAEBA9570 /* ReuseIdentifiableView.swift in Sources */,
-				F11CA6458070CFDFA6A69B87EC77DC01 /* StringExtensions.swift in Sources */,
-				A672743134D7EA5E20CF370597DE6772 /* TestExtensions.swift in Sources */,
-				74AAED2F9AF32E981FEE33700BDDC35A /* UIApplicationExtensions.swift in Sources */,
-				64DC28EBD5219C841D2E24D3A81832C5 /* UICollectionViewExtensions.swift in Sources */,
-				75EBA5CB62EAC055168BA8CF57A1FAD4 /* UIColor+VOKAL.m in Sources */,
-				8A815713043B98E983DA0C061213FEE2 /* UINibExtensions.swift in Sources */,
-				32FA8827E701B904829F5C5F88161B25 /* UIPageControlExtensions.swift in Sources */,
-				CB298CE882989EEE0681E646A5A62CE9 /* UIStackViewExtensions.swift in Sources */,
-				35F49BC857C5BFCCF9CD9FFAE024D9F3 /* UITableViewExtensions.swift in Sources */,
-				130B735244567027BD23672E6DD03AD8 /* UIView+VOKCircle.m in Sources */,
-				5D86601441684B34A55D8117FD9309CB /* UIView+VOKDebug.m in Sources */,
-				BDED08B4AABF3A7AC4FFB4122D195924 /* UIViewController+VOKKeyboard.m in Sources */,
-				7A8451202DC962D9DB09028794F8D306 /* UIViewControllerExtensions.swift in Sources */,
-				C516A2B81347FCBF9CB1320D80DE62A4 /* UIViewExtensions.swift in Sources */,
-				F81F08155812B310858F0C4C3750FEAF /* VOKAlertAction.m in Sources */,
-				BEF4C8898B953881598FF7BE3553AB19 /* VOKAlertHelper.m in Sources */,
-				9F7E11FCF1436B5FD24577283E979B22 /* VOKEmailHelper.m in Sources */,
-				FBBAF0C14047A7FCE5D75A022E89597F /* VOKKeyPathHelper.m in Sources */,
-				5F4508424CB3B5FEA186A14D1FC56739 /* VOKNavigationHelper.m in Sources */,
-				238A06359C710C7BC1E8E1C2617BB689 /* VOKUtilities-dummy.m in Sources */,
+				3A605B884E8DD6B9873B71918CF3C13D /* CollectionExtensions.swift in Sources */,
+				78A956C47EBC2F45A0C43FE81DE75D05 /* IntExtensions.swift in Sources */,
+				E07CFBD2CCFF2AC2761639D9DE2C59D3 /* NSCalendar+VOKAL.m in Sources */,
+				1F150BB916333DC66FC5620B6A07EDE1 /* NSNumberFormatter+VOKAL.m in Sources */,
+				AC588EAAD7FC663494CDFE1438D76443 /* NSPredicate+VOKAL.m in Sources */,
+				86074C27EBF7A65B7C34B3006992DDD8 /* NSString+VOKValidation.m in Sources */,
+				D59B0E25685F3719994C09277C3838C0 /* ReuseIdentifiableView.swift in Sources */,
+				9C7044421379C91F92284994F3483558 /* StringExtensions.swift in Sources */,
+				C7C7D9DBF4C9BB6255FC3B312FC1483A /* TestExtensions.swift in Sources */,
+				C44952D6651317C81F4CDD0CB6EA8E36 /* UIApplicationExtensions.swift in Sources */,
+				702A2D7F05067636B5661BCBBF51E2F9 /* UICollectionViewExtensions.swift in Sources */,
+				E7F0B54ECE2BA72840C3B51D46937EC7 /* UIColor+VOKAL.m in Sources */,
+				63711AFA4326196FCE75BA3E46BE97C7 /* UINibExtensions.swift in Sources */,
+				5899D4F793F4EAC4690362259A1C353F /* UIPageControlExtensions.swift in Sources */,
+				D4F50A00E987BF915F1D65145EAD5328 /* UIStackViewExtensions.swift in Sources */,
+				BDFB24D6ADF638B4CB5826D351EDBB0B /* UITableViewExtensions.swift in Sources */,
+				CC0E93780F3BE70F1AEC617AC449FFAE /* UIView+VOKCircle.m in Sources */,
+				B270ABCFF7AE3FAC209EF2077620E3E0 /* UIView+VOKDebug.m in Sources */,
+				5DF7D307F28F71CA52018740584A6296 /* UIViewController+VOKKeyboard.m in Sources */,
+				A275A4475EC2D6F9211DBAA4CAD57FEC /* UIViewControllerExtensions.swift in Sources */,
+				D676CC0E586D2ACF8EA0950BD0A0C5BC /* UIViewExtensions.swift in Sources */,
+				12ACB30E1B8E1190763C7F9AB7308A27 /* VOKAlertAction.m in Sources */,
+				60E34AC468BCBDD642474AE58F90AFAF /* VOKAlertHelper.m in Sources */,
+				C2E5A9C2786E7F13FF73DA343F5F6024 /* VOKEmailHelper.m in Sources */,
+				56FF0F7551C55E7CDAEDE6BAC0C9F593 /* VOKKeyPathHelper.m in Sources */,
+				49E895AF4486BA675262323C43815123 /* VOKNavigationHelper.m in Sources */,
+				D1C0722EEC365ECAF135C87E6F338DB9 /* VOKUtilities-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		C8C781A1B69FB78302B30EA54F300B5D /* PBXTargetDependency */ = {
+		08538D7DF4DF25C7B6D40DFAF7034FEE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VOKUtilities;
-			target = 7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */;
-			targetProxy = 3B91D3A3CD94F9D493A332F0C0D00C3A /* PBXContainerItemProxy */;
+			target = 34041BF58915475CECBF7974837EFFB1 /* VOKUtilities */;
+			targetProxy = 3BC49A1A89F0D000CE28185FCEDA6289 /* PBXContainerItemProxy */;
 		};
-		9CA2A4D1DAE7E5B568B8C78E5B95785F /* PBXTargetDependency */ = {
+		197E3E2895C8677ED628C81725BB83E9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VOKUtilities;
-			target = 7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */;
-			targetProxy = 77F48A756E3F16ED7050358A0429B2E2 /* PBXContainerItemProxy */;
+			target = 34041BF58915475CECBF7974837EFFB1 /* VOKUtilities */;
+			targetProxy = EA711C6D16CFD1610636F99FEDD19CEB /* PBXContainerItemProxy */;
 		};
-		EE70CD6CB86152E0AF71A2DE0E2058AE /* PBXTargetDependency */ = {
+		2A9FE2ED7DF4F3F70C02206130F770F5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-3288a73d";
-			target = 8408DDD7AD3411FF55AF08891D7BC367 /* VOKUtilities-3288a73d */;
-			targetProxy = 98954D555D99F50503D08946BD205016 /* PBXContainerItemProxy */;
+			target = 5F11AA50ACF05F346CDA77439859B6DA /* VOKUtilities-3288a73d */;
+			targetProxy = CD9811DB2D790F4E05E0FA384FFECA73 /* PBXContainerItemProxy */;
 		};
-		5F53E2E296A0207EABF78A78A0FF7114 /* PBXTargetDependency */ = {
+		2D506C590D7D544AC1EBE459F3942BD2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = VOKUtilities;
-			target = 7BF6F455B6726E7C85743DC17CAFDD20 /* VOKUtilities */;
-			targetProxy = A7B2619F408A2AAA443CA385B70E4C34 /* PBXContainerItemProxy */;
+			target = 34041BF58915475CECBF7974837EFFB1 /* VOKUtilities */;
+			targetProxy = 146A92EC64A2D16D357EB77DA390A795 /* PBXContainerItemProxy */;
 		};
-		132821AE7F3482F5EB9CD991218BCE45 /* PBXTargetDependency */ = {
+		58BAD50D8AC777AED9D1B60DC25271DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-d8783a65";
-			target = 7FED5C7AEFE8FA987C032F83E89A51C3 /* VOKUtilities-d8783a65 */;
-			targetProxy = 620A6D1866AC9A8823CDE4A07A4665BE /* PBXContainerItemProxy */;
+			target = 986D4576ACB401B6E7833D76875E6E80 /* VOKUtilities-d8783a65 */;
+			targetProxy = 10AF388CFB1F53E6AC46B4DAC4BC0D44 /* PBXContainerItemProxy */;
 		};
-		956191F3C7BF2C98097B76880853374F /* PBXTargetDependency */ = {
+		5DCE3358A13F0A04591487744DB31A31 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-d8783a65";
-			target = 7FED5C7AEFE8FA987C032F83E89A51C3 /* VOKUtilities-d8783a65 */;
-			targetProxy = 352C5753D09C8ACF22707DD9C4684404 /* PBXContainerItemProxy */;
+			target = 986D4576ACB401B6E7833D76875E6E80 /* VOKUtilities-d8783a65 */;
+			targetProxy = 34C1C52E2DD76F705DAF9DB8A7F45FD0 /* PBXContainerItemProxy */;
 		};
-		88B347F0FB622E4EE4A85AF9A1459C7C /* PBXTargetDependency */ = {
+		BF5B7BFF62FC82DC9DF1962D4A57BFE5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-6aa4e1e5";
-			target = D66B399E182882255B61F0D42ED65BDC /* VOKUtilities-6aa4e1e5 */;
-			targetProxy = 1B03D844BC65780462DF112CE6344BF4 /* PBXContainerItemProxy */;
+			target = 94DBDDEF06EFF716048EEF3645387066 /* VOKUtilities-6aa4e1e5 */;
+			targetProxy = CAE9568E841FD5EDF926E0800BBF1012 /* PBXContainerItemProxy */;
 		};
-		8B3D2AF7153FB2AD4103CCA95C99AA56 /* PBXTargetDependency */ = {
+		C752E87EB936BDBECE70018E5AE377C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = KIF;
-			target = 99C2EE2358EE6808D004D553CCB17A0D /* KIF */;
-			targetProxy = BCD9C31F93F147FED5C19D2C393DC0B0 /* PBXContainerItemProxy */;
+			target = 82B5B837E11665D1EEE2588148E3C1A7 /* KIF */;
+			targetProxy = CC56A34C6F6A2CA9DCF0A2D5C23D496A /* PBXContainerItemProxy */;
 		};
-		C0BB008BFBDF0A9AF5745AC88722FFA9 /* PBXTargetDependency */ = {
+		E0FDDCA69DD56EE31614AB2E6067AEAE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "VOKUtilities-3288a73d";
-			target = 8408DDD7AD3411FF55AF08891D7BC367 /* VOKUtilities-3288a73d */;
-			targetProxy = 59F6BA70798B68B868EAF8EBDE3C646A /* PBXContainerItemProxy */;
+			target = 5F11AA50ACF05F346CDA77439859B6DA /* VOKUtilities-3288a73d */;
+			targetProxy = A50947147F7265C150DA9183148EA526 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		5F43FD6CA053CFE317F55116BEE879BD /* Debug */ = {
+		312971B26C95DED61C01DA3971C87812 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ED67C606E320E7552854220756D4CCD6 /* Pods-VOKUtilities.debug.xcconfig */;
+			baseConfigurationReference = F844F4295C7FF47A9665AC336786D99E /* Pods-VOKUtilities.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1744,9 +1744,9 @@
 			};
 			name = Debug;
 		};
-		83729DECF9C8FEC466E704645BB935C3 /* Release */ = {
+		356F382037AFDE1ED1A0DC5ED2F9DD19 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8DA17411F3736DF097028C4A1D4898EE /* Pods-VOKUtilities-Tests.release.xcconfig */;
+			baseConfigurationReference = 1A9B9EF968E0FF4C24C53B00C2F1B574 /* Pods-VOKUtilities-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1769,9 +1769,9 @@
 			};
 			name = Release;
 		};
-		25812A11847E1245E4458F9F22B9FB14 /* Release */ = {
+		437BEBCDFD70AA859EBCB1AEFF05287E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F0986C9E216ADEE673E9422FE401F0E1 /* Pods-VOKUtilities-tvOS.release.xcconfig */;
+			baseConfigurationReference = 2DF28D9FB0A77A7D6810DA3DA867835F /* Pods-VOKUtilities-tvOS.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1790,9 +1790,9 @@
 			};
 			name = Release;
 		};
-		6221ADDE2DD1FEB406B968989D15E4C8 /* Release */ = {
+		5B22D4AFFA7494CECB0216E92757609D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 13E8F743E7B20474C0FC3B5DAB277F35 /* VOKUtilities-6aa4e1e5.xcconfig */;
+			baseConfigurationReference = EFB0B18956FDD720D9DD54564755B2BB /* VOKUtilities-6aa4e1e5.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1815,9 +1815,9 @@
 			};
 			name = Release;
 		};
-		65DB5717148C5892D54B9E3045C6A0AC /* Debug */ = {
+		645E8349D2E66090CC9786F100C177B0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C1A8A4CBFE4925DA8C6F9B10FE36B53 /* Pods-VOKUtilities-Tests.debug.xcconfig */;
+			baseConfigurationReference = 0517A9AC6133FD1B2804E8E5E6824807 /* Pods-VOKUtilities-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1839,9 +1839,9 @@
 			};
 			name = Debug;
 		};
-		71EB15ABC7BDB55B570851E63C22F961 /* Debug */ = {
+		6CA2D8D9E3B60D9D90EE55B0DE8B1C03 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7BE35F55E952595F1F570BE22C10323A /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */;
+			baseConfigurationReference = BB61F8D7346713C87C910D82A030E7A2 /* Pods-VOKUtilities-watchOS Extension.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -1860,9 +1860,9 @@
 			};
 			name = Debug;
 		};
-		7F863142F29A67D4AE0BF7BEBEE23FFF /* Debug */ = {
+		798A951985C616BE62C7490C2FC35AAE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B6F3052431F469A793BE88E4C436B0E /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 535DEC30191070958A7B52EFA68E623D /* Pods-VOKUtilities-tvOS-Tests-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1880,9 +1880,9 @@
 			};
 			name = Debug;
 		};
-		A646CEF7AA4039F9C04C896FDA0E2284 /* Debug */ = {
+		8054BED69B2292B252AFE87EBF939815 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72F5DB8C343D2FD7F7CEFD948C7E3163 /* Pods-VOKUtilities-UITests.debug.xcconfig */;
+			baseConfigurationReference = D49B7E75B2EC784410F6020249886EB7 /* Pods-VOKUtilities-UITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1904,9 +1904,9 @@
 			};
 			name = Debug;
 		};
-		7FA657B0EB45BA521EE80CC189A18D93 /* Release */ = {
+		877C34C75420205AEB8D4D34D1F215A9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84DC51BF57AF57827E9A253D63707FF0 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */;
+			baseConfigurationReference = 16ACF05D99F205680763E44C25073327 /* Pods-VOKUtilities-tvOS-Tests-tvOS.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1925,9 +1925,9 @@
 			};
 			name = Release;
 		};
-		25E8BAD6FF05FE5D0C6B0D6C3B7DB29F /* Release */ = {
+		87CA5680A0E165CB7A1D1E9541B10B3A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF15B543402F7F49A37C463991728D76 /* KIF.xcconfig */;
+			baseConfigurationReference = 81A17D35F50E350E5ADA4F8213AC0ADB /* KIF.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1951,9 +1951,9 @@
 			};
 			name = Release;
 		};
-		038349C263D263C4384AF1BAFB56DCE4 /* Release */ = {
+		8841DB4D9F0A9A103ED767BE8782EDFC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E702990E1D564EED03C1C1F7FC2F4926 /* Pods-VOKUtilities-OSX.release.xcconfig */;
+			baseConfigurationReference = 1983AB640BD3B786ED8CEF6ABEE7055F /* Pods-VOKUtilities-OSX.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1973,9 +1973,9 @@
 			};
 			name = Release;
 		};
-		17D1333A8CE09030241354A8BE9C3104 /* Release */ = {
+		8979FC696B58F0A79A5ADB4CCFE5848A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD9901C057035ECE56BB8051D55F0633 /* Pods-VOKUtilities.release.xcconfig */;
+			baseConfigurationReference = 5042A0A09414A01B7F161560893592AA /* Pods-VOKUtilities.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -1998,9 +1998,9 @@
 			};
 			name = Release;
 		};
-		65526C7E3F4B269D59FDFD94EDEDF8EB /* Debug */ = {
+		8E123715414D7BD84B164C7F873315E0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D99E80F18BCD42A08B320FC4192E2FFA /* VOKUtilities-3288a73d.xcconfig */;
+			baseConfigurationReference = D4035EEAE134DA9E9E58D693E0032ED7 /* VOKUtilities-3288a73d.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "-";
@@ -2023,9 +2023,9 @@
 			};
 			name = Debug;
 		};
-		0409479C743AAF47CEF9B096DE794037 /* Debug */ = {
+		8F182F136333F01CEDA68BEE0C99C883 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 76A781B779B12B2F733B1116E68F29EB /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */;
+			baseConfigurationReference = DB700D0A5D7C153538316439963A2755 /* Pods-VOKUtilities-OSX-Tests-OSX.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -2045,9 +2045,9 @@
 			};
 			name = Debug;
 		};
-		6008ABD7F986BCBFD9A663DD9CC48E21 /* Debug */ = {
+		965632F0D9C1679DD9F3D457F2BF2DC3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F8BFCFF33D82958419B37BCA846C71B1 /* VOKUtilities-d8783a65.xcconfig */;
+			baseConfigurationReference = D5CEAF434166C94DE59DAAE7DD4F5DEA /* VOKUtilities-d8783a65.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2068,9 +2068,9 @@
 			};
 			name = Debug;
 		};
-		CA4F131465F9EC80A985ECD3CFF50214 /* Release */ = {
+		A8AA4B5CB408D9721E2FB1098F766F68 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F66D42ACC4DFF844005E41B9E0CBC148 /* VOKUtilities.xcconfig */;
+			baseConfigurationReference = B29767A5C3680270E1CFAEC28527606C /* VOKUtilities.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2096,9 +2096,9 @@
 			};
 			name = Release;
 		};
-		A6FF0DAD7D4E9C3DE3D35EF806C0B9B5 /* Release */ = {
+		A95DF879D094AA21791305165145E37C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 579E47755F2232EABA83A095AC14CD4F /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */;
+			baseConfigurationReference = BEFA062B53BA6DD40FCEC89CBCC19AA3 /* Pods-VOKUtilities-OSX-Tests-OSX.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -2118,9 +2118,9 @@
 			};
 			name = Release;
 		};
-		4505E0BECFE3753F3F9652BE5508DB65 /* Release */ = {
+		AD2C13E748D899537748BB10027053DE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D99E80F18BCD42A08B320FC4192E2FFA /* VOKUtilities-3288a73d.xcconfig */;
+			baseConfigurationReference = D4035EEAE134DA9E9E58D693E0032ED7 /* VOKUtilities-3288a73d.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "-";
@@ -2143,9 +2143,9 @@
 			};
 			name = Release;
 		};
-		E26C0451C833134B6BBCE37DE0C1C998 /* Debug */ = {
+		B1A13D93945CA665A018AFA53A12CDA8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 64DD439F1A6E7228733309C3C4B2F0F1 /* Pods-VOKUtilities-tvOS.debug.xcconfig */;
+			baseConfigurationReference = 6DC5BCE78DF9B83DFA827C00999804D2 /* Pods-VOKUtilities-tvOS.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2163,9 +2163,9 @@
 			};
 			name = Debug;
 		};
-		06EF23E849CEA892C878BCAC7276AFCE /* Debug */ = {
+		B27EDF2D1C4B4D00BC490BFD0E2685B9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 13E8F743E7B20474C0FC3B5DAB277F35 /* VOKUtilities-6aa4e1e5.xcconfig */;
+			baseConfigurationReference = EFB0B18956FDD720D9DD54564755B2BB /* VOKUtilities-6aa4e1e5.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2187,7 +2187,7 @@
 			};
 			name = Debug;
 		};
-		78F0498F2AF1B86F8B7B7477CD49552F /* Debug */ = {
+		B65A1189A4C9B732EA0DCFFFCA824F09 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2254,9 +2254,9 @@
 			};
 			name = Debug;
 		};
-		D78EF48B0F3173A8EFECFE2C804D4354 /* Debug */ = {
+		B9D9112ABADF3D56A460289A74C06618 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F66D42ACC4DFF844005E41B9E0CBC148 /* VOKUtilities.xcconfig */;
+			baseConfigurationReference = B29767A5C3680270E1CFAEC28527606C /* VOKUtilities.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
@@ -2281,9 +2281,9 @@
 			};
 			name = Debug;
 		};
-		342CA0F5F58115C1CD50F576462D8CBB /* Debug */ = {
+		C21FB642800EFA950FEA293DD30E56E9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EF15B543402F7F49A37C463991728D76 /* KIF.xcconfig */;
+			baseConfigurationReference = 81A17D35F50E350E5ADA4F8213AC0ADB /* KIF.xcconfig */;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -2306,9 +2306,9 @@
 			};
 			name = Debug;
 		};
-		513C814E2C6F36FC8099AE0C66A98307 /* Release */ = {
+		D4083DD2DB646E335CCECD299B0C3748 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F8BFCFF33D82958419B37BCA846C71B1 /* VOKUtilities-d8783a65.xcconfig */;
+			baseConfigurationReference = D5CEAF434166C94DE59DAAE7DD4F5DEA /* VOKUtilities-d8783a65.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2330,9 +2330,9 @@
 			};
 			name = Release;
 		};
-		E3341B9D0B3C28C14C687DB6E2B867FC /* Release */ = {
+		D7220B83D47D4828D26E620101DC022F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 13B07AA527C974F3D6DF671BAF5F0800 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */;
+			baseConfigurationReference = 58B99DC0D6F954E7E2947E02D026A960 /* Pods-VOKUtilities-watchOS Extension.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -2352,7 +2352,7 @@
 			};
 			name = Release;
 		};
-		29915A707A12A2C46DAA846C396CAB6F /* Release */ = {
+		E27A9E2FFC0A7F4C6633B24A99B03DC7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2415,9 +2415,9 @@
 			};
 			name = Release;
 		};
-		CF54BB7A864CDFEB8869B6D29E3E41CD /* Release */ = {
+		EB6B3885BB950CF132FA444FD426CFD8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FAE18B5CBCA58BE2C1F5F17C91E25481 /* Pods-VOKUtilities-UITests.release.xcconfig */;
+			baseConfigurationReference = 477C6FDE8319E8DE89215F370869DC4E /* Pods-VOKUtilities-UITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -2440,9 +2440,9 @@
 			};
 			name = Release;
 		};
-		5E673B530D6030BCE743E923DBD323DB /* Debug */ = {
+		ED08FB02E2962741C292C00C4C22ECAE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CD428AC25745BAAB289F14779E117C98 /* Pods-VOKUtilities-OSX.debug.xcconfig */;
+			baseConfigurationReference = 122F88ABE31C9661F41BF8C723518A9B /* Pods-VOKUtilities-OSX.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
@@ -2465,128 +2465,128 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		4F620C182733A2CD75D5FC38627C9104 /* Build configuration list for PBXNativeTarget "KIF" */ = {
+		0924E574E064C5B5BAED3A4A3FB50D16 /* Build configuration list for PBXNativeTarget "KIF" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				342CA0F5F58115C1CD50F576462D8CBB /* Debug */,
-				25E8BAD6FF05FE5D0C6B0D6C3B7DB29F /* Release */,
+				C21FB642800EFA950FEA293DD30E56E9 /* Debug */,
+				87CA5680A0E165CB7A1D1E9541B10B3A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		930AE6E527753812537FF661A0595C3B /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS-Tests-tvOS" */ = {
+		10ECE019846AACED1A6455676D7439ED /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS-Tests-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7F863142F29A67D4AE0BF7BEBEE23FFF /* Debug */,
-				7FA657B0EB45BA521EE80CC189A18D93 /* Release */,
+				798A951985C616BE62C7490C2FC35AAE /* Debug */,
+				877C34C75420205AEB8D4D34D1F215A9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		FC02AE59B0DCC1367E03651BD0868F72 /* Build configuration list for PBXProject "Pods" */ = {
+		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				78F0498F2AF1B86F8B7B7477CD49552F /* Debug */,
-				29915A707A12A2C46DAA846C396CAB6F /* Release */,
+				B65A1189A4C9B732EA0DCFFFCA824F09 /* Debug */,
+				E27A9E2FFC0A7F4C6633B24A99B03DC7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B9BAE4363822247CC25D199794E9A8F0 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX" */ = {
+		4C12E3EFDF0133BF7642E9AD48325B8E /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5E673B530D6030BCE743E923DBD323DB /* Debug */,
-				038349C263D263C4384AF1BAFB56DCE4 /* Release */,
+				ED08FB02E2962741C292C00C4C22ECAE /* Debug */,
+				8841DB4D9F0A9A103ED767BE8782EDFC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DDEB6851C10F50F34FC0FD1C6951E499 /* Build configuration list for PBXNativeTarget "VOKUtilities-6aa4e1e5" */ = {
+		5FAF5E3D34E07A0623964CFA68A6A314 /* Build configuration list for PBXNativeTarget "VOKUtilities-6aa4e1e5" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				06EF23E849CEA892C878BCAC7276AFCE /* Debug */,
-				6221ADDE2DD1FEB406B968989D15E4C8 /* Release */,
+				B27EDF2D1C4B4D00BC490BFD0E2685B9 /* Debug */,
+				5B22D4AFFA7494CECB0216E92757609D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		47FF61D2CE026D18CC038CBBAF01EE5E /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-watchOS Extension" */ = {
+		60CCD58F2FAAC1A17DB1E94BF0EDCC5F /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-watchOS Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				71EB15ABC7BDB55B570851E63C22F961 /* Debug */,
-				E3341B9D0B3C28C14C687DB6E2B867FC /* Release */,
+				6CA2D8D9E3B60D9D90EE55B0DE8B1C03 /* Debug */,
+				D7220B83D47D4828D26E620101DC022F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BFEF623AB493671B39040FD1DBA758AE /* Build configuration list for PBXNativeTarget "VOKUtilities" */ = {
+		636CD395F9E1F15BCE729FD6B5FCD30E /* Build configuration list for PBXNativeTarget "VOKUtilities" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D78EF48B0F3173A8EFECFE2C804D4354 /* Debug */,
-				CA4F131465F9EC80A985ECD3CFF50214 /* Release */,
+				B9D9112ABADF3D56A460289A74C06618 /* Debug */,
+				A8AA4B5CB408D9721E2FB1098F766F68 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D6E7166B6CA1362E3D88A00035EB8E9C /* Build configuration list for PBXNativeTarget "VOKUtilities-3288a73d" */ = {
+		AA37849DD7156BF340745ADC37DB9CF8 /* Build configuration list for PBXNativeTarget "VOKUtilities-3288a73d" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				65526C7E3F4B269D59FDFD94EDEDF8EB /* Debug */,
-				4505E0BECFE3753F3F9652BE5508DB65 /* Release */,
+				8E123715414D7BD84B164C7F873315E0 /* Debug */,
+				AD2C13E748D899537748BB10027053DE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		900ADBC95F05BF1913234B3BAD9EBCF3 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-Tests" */ = {
+		AE38973CE906E7F6DBC1F565324BB585 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				65DB5717148C5892D54B9E3045C6A0AC /* Debug */,
-				83729DECF9C8FEC466E704645BB935C3 /* Release */,
+				645E8349D2E66090CC9786F100C177B0 /* Debug */,
+				356F382037AFDE1ED1A0DC5ED2F9DD19 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E1972B2D3E669C45DA7B174A2F5ACA3D /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX-Tests-OSX" */ = {
+		C2D98EDF7CB5F8045FFFD96C38268A99 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-OSX-Tests-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0409479C743AAF47CEF9B096DE794037 /* Debug */,
-				A6FF0DAD7D4E9C3DE3D35EF806C0B9B5 /* Release */,
+				8F182F136333F01CEDA68BEE0C99C883 /* Debug */,
+				A95DF879D094AA21791305165145E37C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F053C8D2DE88FE93A7718783E1C403FC /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities" */ = {
+		D4EF0495899156912BE651C31EEEE651 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5F43FD6CA053CFE317F55116BEE879BD /* Debug */,
-				17D1333A8CE09030241354A8BE9C3104 /* Release */,
+				312971B26C95DED61C01DA3971C87812 /* Debug */,
+				8979FC696B58F0A79A5ADB4CCFE5848A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		5E13B445FF39DB0EC6ACAFA037124CFE /* Build configuration list for PBXNativeTarget "VOKUtilities-d8783a65" */ = {
+		D843D5D60CE6977DE337553CCF254D0E /* Build configuration list for PBXNativeTarget "VOKUtilities-d8783a65" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6008ABD7F986BCBFD9A663DD9CC48E21 /* Debug */,
-				513C814E2C6F36FC8099AE0C66A98307 /* Release */,
+				965632F0D9C1679DD9F3D457F2BF2DC3 /* Debug */,
+				D4083DD2DB646E335CCECD299B0C3748 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		58DF8DC0CDA164F0894EAC570B005B45 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-UITests" */ = {
+		DEDB9E162120CF1B5A497E018845A89D /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A646CEF7AA4039F9C04C896FDA0E2284 /* Debug */,
-				CF54BB7A864CDFEB8869B6D29E3E41CD /* Release */,
+				8054BED69B2292B252AFE87EBF939815 /* Debug */,
+				EB6B3885BB950CF132FA444FD426CFD8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1A9B60F2BF33F98364309DA4E4EB66D7 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS" */ = {
+		E62ACB7337DA6B8EAE75FF3DA1FB26D7 /* Build configuration list for PBXNativeTarget "Pods-VOKUtilities-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E26C0451C833134B6BBCE37DE0C1C998 /* Debug */,
-				25812A11847E1245E4458F9F22B9FB14 /* Release */,
+				B1A13D93945CA665A018AFA53A12CDA8 /* Debug */,
+				437BEBCDFD70AA859EBCB1AEFF05287E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pod/VOKSwiftHelpers/UIViewExtensions.swift
+++ b/Pod/VOKSwiftHelpers/UIViewExtensions.swift
@@ -11,7 +11,7 @@ extension UIView {
     /// Pin a view to the top/bottom/leading/trailing anchors of a given view.
     ///
     /// - Parameter pinningView: the view to pin to.
-    func pin(to pinningView: UIView) {
+    public func pin(to pinningView: UIView) {
         translatesAutoresizingMaskIntoConstraints = false
         pinningView.addSubview(self)
         
@@ -20,7 +20,7 @@ extension UIView {
             bottomAnchor.constraint(equalTo: pinningView.bottomAnchor),
             leadingAnchor.constraint(equalTo: pinningView.leadingAnchor),
             trailingAnchor.constraint(equalTo: pinningView.trailingAnchor),
-        ])
+            ])
     }
     
     /// Convenience static member for a view with a clear background color.

--- a/VOKUtilities.podspec
+++ b/VOKUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "VOKUtilities"
-  s.version          = "0.14.0"
+  s.version          = "0.15.0"
   s.summary          = "Assorted category and utility classes for iDevelopment"
   s.homepage         = "https://github.com/vokal/VOKUtilities"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
Simple PR to allow for access to the pin(to:) func swift helper in UIViewExtensions. 

bumped podspec
pulled into the example

@vokal/ios-developers please review
